### PR TITLE
Adding Contributing, Issue Template, and Readme pages

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -16,7 +16,7 @@ Here are some ways you can contribute to this documentation:
 * To make small changes to an article, [Contribute using GitHub](#contribute-using-github).
 * To make large changes, or changes that involve code, [Contribute using Git](#contribute-using-git).
 * Report documentation bugs via GitHub Issues.
-* Request new documentation at the [Office Developer Platform UserVoice](https://excel.uservoice.com/forums/274580-excel-for-the-web?category_id=143439) site.
+* Request new documentation at the [Excel for the web UserVoice](https://excel.uservoice.com/forums/274580-excel-for-the-web?category_id=143439) site.
 
 ## Contribute using GitHub
 

--- a/Issue_Template.md
+++ b/Issue_Template.md
@@ -1,5 +1,5 @@
 <!---
-Welcome to the Office Scripts fpr Excel on the web documentation repository.
+Welcome to the Office Scripts for Excel on the web documentation repository.
 
 To report an issue with the Office Scripts documentation, please provide the article URL and describe the issue below. Alternatively, if you want to submit a pull request with your recommended documentation changes, we will review your contributions and update our documentation accordingly.
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# Office Add-ins documentation
+# Office Scripts for Excel on the web documentation
 
-Welcome to the Office Add-ins documentation repo. In this repository, you can find the documentation source files for Office JavaScript API concepts, quick starts, tutorials, and how-to guides. For the best experience, we recommend you view this content on [docs.microsoft.com](https://docs.microsoft.com/office-scripts-docs).
+Welcome to the Office Scripts documentation repo. In this repository, you can find the documentation source files for Office Scripts tutorials and how-to guides. For the best experience, we recommend you view this content on [docs.microsoft.com](https://docs.microsoft.com/office-scripts-docs).
 
-> **Note**: You can find the Office JavaScript API reference documentation source files in the [office-js-docs-reference](https://github.com/OfficeDev/office-js-docs-reference) repository.
+> **Note**: You can find the reference documentation source files for Office JavaScript API (on which Office Scripts run) in the [office-js-docs-reference](https://github.com/OfficeDev/office-js-docs-reference) repository. These APIs contain all the potential Excel operations for your scripts.
 
 ## Give us your feedback
 
-The goal of the repo is to provide developer education on the platform's behavior. As such, issues should pertain to that educational content. Please [submit an issue](https://github.com/OfficeDev/office-scripts-docs/issues) for the following scenarios:
+The goal of the repo is to provide developer education about Office Scripts. As such, issues should pertain to that educational content. Please [submit an issue](https://github.com/OfficeDev/office-scripts-docs/issues) for the following scenarios:
 
-- Information needed to succeed in developing Office Add-ins is missing or incomplete.
+- Information needed to succeed in developing Office Scripts is missing or incomplete.
 - Information is inaccurate or obsolete.
 - You find typos, grammatical mistakes, or other problems with the articles.
 - Articles are organized in a confusing or unintuitive manner.
@@ -21,7 +21,7 @@ If you are seeing product behavior that differs from the documentation, please p
 
 We also encourage you to fork, make the fix, and do a pull request of your proposed changes. For details, see [Contribute to this documentation](Contributing.md).
 
-If your issue is not related to the Office Add-ins documentation, please post it to one of the following channels instead:
+If your issue is not related to the Office Scripts documentation, please post it to one of the following channels instead:
 
 - To ask a question about designing Office Scripts or the Office.js API that runs Office Scripts, post your question to Stack Overflow and tag it with the "office-js" tag (http://stackoverflow.com/questions/tagged/office-js).
 - To report an issue with the Office.js API, create the issue in the OfficeDev/office-js repository (https://github.com/OfficeDev/office-js), which members of the product team monitor for customer-reported issues.


### PR DESCRIPTION
These are based off of the office-js-docs-pr [Contributing](https://github.com/OfficeDev/office-js-docs-pr/blob/master/Contributing.md), [Issue Template](https://github.com/OfficeDev/office-js-docs-pr/blob/master/Issue_Template.md), and [readme](https://github.com/OfficeDev/office-js-docs-pr/blob/master/README.md) pages.