### PR TITLE
Improve metadata descriptions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 layout: LandingPage
 ms.topic: landing-page
 title: Office Scripts documentation
-description: Resources for learning about Office Scripts.
+description: 'Resources for learning about Office Scripts, including tutorials conceptual articles, and samples.'
 ms.date: 01/07/2020
 localization_priority: Priority
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 layout: LandingPage
 ms.topic: landing-page
 title: Office Scripts documentation
-description: 'Resources for learning about Office Scripts, including tutorials conceptual articles, and samples.'
+description: 'Resources for learning Office Scripts in Excel on the web, including tutorials, conceptual articles, and code samples.'
 ms.date: 01/07/2020
 localization_priority: Priority
 ---

--- a/docs/resources/excel-samples.md
+++ b/docs/resources/excel-samples.md
@@ -1,6 +1,6 @@
 ---
 title: 'Sample scripts for Office Scripts in Excel on the web'
-description: 'A collection of examples and samples to use with Office Scripts in Excel on the web.'
+description: 'A collection of code samples to use with Office Scripts in Excel on the web.'
 ms.date: 01/07/2020
 localization_priority: Normal
 ---

--- a/docs/resources/excel-samples.md
+++ b/docs/resources/excel-samples.md
@@ -1,6 +1,6 @@
 ---
 title: 'Sample scripts for Office Scripts in Excel on the web'
-description: 'A collection of samples to use with Office Scripts in Excel on the web.'
+description: 'A collection of examples and samples to use with Office Scripts in Excel on the web.'
 ms.date: 01/07/2020
 localization_priority: Normal
 ---

--- a/docs/testing/undo.md
+++ b/docs/testing/undo.md
@@ -1,6 +1,6 @@
 ---
 title: 'Undo the effects of an Office Script'
-description: 'Use the version history of Excel on the web to undo a script.'
+description: 'Use the version history of Excel on the web to undo the effects of running a script.'
 ms.date: 12/13/2019
 localization_priority: Normal
 ---

--- a/docs/testing/undo.md
+++ b/docs/testing/undo.md
@@ -1,11 +1,11 @@
 ---
-title: 'Undo the effects of an Office Script'
-description: 'Use the version history of Excel on the web to undo the effects of running a script.'
-ms.date: 12/13/2019
+title: 'Undo the changes made by running an Office Script'
+description: 'Use the version history of Excel on the web to undo the changes made by running a script.'
+ms.date: 01/08/2019
 localization_priority: Normal
 ---
 
-# Undo the effects of an Office Script
+# Undo the changes made by running an Office Script
 
 You cannot undo a script using the **Undo** command. Instead, you must restore a previous version of the workbook from your cloud storage.
 

--- a/docs/tutorials/excel-tutorial.md
+++ b/docs/tutorials/excel-tutorial.md
@@ -1,6 +1,6 @@
 ---
 title: 'Record, edit, and create Office Scripts in Excel on the web'
-description: 'A tutorial teaching the basics of writing and editing Office Scripts.'
+description: 'A tutorial teaching the basics of writing and editing Office Scripts, including reading data from and and writing data to a workbook.'
 ms.date: 01/07/2020
 localization_priority: Normal
 ---

--- a/docs/tutorials/excel-tutorial.md
+++ b/docs/tutorials/excel-tutorial.md
@@ -1,6 +1,6 @@
 ---
 title: 'Record, edit, and create Office Scripts in Excel on the web'
-description: 'A tutorial teaching the basics of writing and editing Office Scripts, including reading data from and and writing data to a workbook.'
+description: 'A tutorial about the basics of Office Scripts, including reading data from and and writing data to a workbook.'
 ms.date: 01/07/2020
 localization_priority: Normal
 ---


### PR DESCRIPTION
According to the CATS report, the descriptions for these pages were not of sufficient length. They have been adjusted accordingly.