### PR TITLE
Adding shared flow note

### DIFF
--- a/docs/develop/power-automate-integration.md
+++ b/docs/develop/power-automate-integration.md
@@ -9,8 +9,8 @@ localization_priority: Normal
 
 [Power Automate](https://flow.microsoft.com) integrates your script into a larger workflow. You can use Power Automate do things like add the contents of an email to a worksheet's table or create actions in your project management tools based on workbook comments. If you are new to Power Automate, we recommend visiting [Get started with Power Automate](https://docs.microsoft.com/power-automate/getting-started). There, you can learn more about automating your workflows across multiple services.
 
-> [!NOTE]
-> Currently, Office Scripts can't be run from a [shared flow](https://docs.microsoft.com/power-automate/share-buttons). Scripts can only be run by the user who created the script, even through Power Automate.
+> [!IMPORTANT]
+> Currently, you can't run Office Scripts from a [shared flow](/power-automate/share-buttons). Only the user who created a script can run it, even through Power Automate.
 
 ## Passing data from Power Automate into a script
 

--- a/docs/develop/power-automate-integration.md
+++ b/docs/develop/power-automate-integration.md
@@ -7,7 +7,7 @@ localization_priority: Normal
 
 # Integrate Office Scripts with Power Automate
 
-[Power Automate](https://flow.microsoft.com) integrates your script into a larger workflow. You can use Power Automate do things like add the contents of an email to a worksheet's table or create actions in your project management tools based on workbook comments. If you are new to Power Automate, we recommend visiting [Get started with Power Automate](https://docs.microsoft.com/power-automate/getting-started). There, you can learn more about automating your workflows across multiple services.
+[Power Automate](https://flow.microsoft.com) integrates your script into a larger workflow. You can use Power Automate do things like add the contents of an email to a worksheet's table or create actions in your project management tools based on workbook comments. If you are new to Power Automate, we recommend visiting [Get started with Power Automate](/power-automate/getting-started). There, you can learn more about automating your workflows across multiple services.
 
 > [!IMPORTANT]
 > Currently, you can't run Office Scripts from a [shared flow](/power-automate/share-buttons). Only the user who created a script can run it, even through Power Automate.

--- a/docs/develop/power-automate-integration.md
+++ b/docs/develop/power-automate-integration.md
@@ -1,13 +1,16 @@
 ---
 title: 'Integrate Office Scripts with Power Automate'
 description: 'How to get Office Scripts for Excel on the web working with a Power Automate workflow.'
-ms.date: 01/31/2020
+ms.date: 03/25/2020
 localization_priority: Normal
 ---
 
 # Integrate Office Scripts with Power Automate
 
 [Power Automate](https://flow.microsoft.com) integrates your script into a larger workflow. You can use Power Automate do things like add the contents of an email to a worksheet's table or create actions in your project management tools based on workbook comments. If you are new to Power Automate, we recommend visiting [Get started with Power Automate](https://docs.microsoft.com/power-automate/getting-started). There, you can learn more about automating your workflows across multiple services.
+
+> [!NOTE]
+> Currently, Office Scripts can't be run from a [shared flow](https://docs.microsoft.com/power-automate/share-buttons). Scripts can only be run by the user who created the script, even through Power Automate.
 
 ## Passing data from Power Automate into a script
 


### PR DESCRIPTION
Office Scripts can't be run through shared Power Automate flows. This PR adds documentation to that effect.