### PR TITLE
Adding notes about external libraries

### DIFF
--- a/docs/develop/javascript-objects.md
+++ b/docs/develop/javascript-objects.md
@@ -142,9 +142,9 @@ async function main(context: Excel.RequestContext) {
 
 ```
 
-## Using external JavaScript libraries
+## Use of external JavaScript libraries is not supported
 
-Office Script don't support the use of external, third-party libraries. Your script can only use the built-in JavaScript objects and the Office Scripts APIs.
+Office Scripts don't support the use of external, third-party libraries. Your script can only use the built-in JavaScript objects and the Office Scripts APIs.
 
 ## See also
 

--- a/docs/develop/javascript-objects.md
+++ b/docs/develop/javascript-objects.md
@@ -1,7 +1,7 @@
 ---
 title: 'Using built-in JavaScript objects in Office Scripts'
 description: 'How to call built-in JavaScript APIs from an Office Script in Excel on the web.'
-ms.date: 04/06/2020
+ms.date: 04/08/2020
 localization_priority: Normal
 ---
 
@@ -141,6 +141,10 @@ async function main(context: Excel.RequestContext) {
 }
 
 ```
+
+## Using external JavaScript libraries
+
+Office Script don't support the use of external, third-party libraries. Your script can only use the built-in JavaScript objects and the Office Scripts APIs.
 
 ## See also
 

--- a/docs/overview/code-editor-environment.md
+++ b/docs/overview/code-editor-environment.md
@@ -1,7 +1,7 @@
 ---
 title: 'Office Scripts Code Editor environment'
 description: 'The prerequisites and environment information for Office Scripts in Excel on the web.'
-ms.date: 01/21/2020
+ms.date: 04/08/2020
 localization_priority: Normal
 ---
 
@@ -27,6 +27,10 @@ Office Scripts use a specialized version the Office JavaScript APIs that are use
 IntelliSense is a Code Editor feature that helps prevent typos and syntax errors as you edit your script. It displays possible object and field names as you type, as well as inline documentation for every API.
 
 The Excel Code Editor uses the same IntelliSense engine as Visual Studio Code. To learn more about the feature, visit [Visual Studio Code's IntelliSense Features](https://code.visualstudio.com/docs/editor/intellisense#_intellisense-features).
+
+## External library support
+
+Office Scripts do not support the usage of external, third-party JavaScript libraries. You are currently unable to call any library other than the Office Scripts APIs from a script. You do still have access to any [built-in JavaScript object](../develop/javascript-objects.md), such as [Math](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math).
 
 ## See also
 


### PR DESCRIPTION
Office Scripts don't support calls to external libraries. This PR makes that clear to developers.