### PR TITLE
Conceptual-side monikers

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -11,7 +11,7 @@
       "build_output_subfolder": "office-scripts-docs",
       "locale": "en-us",
       "monikers": [],
-      "moniker_ranges": [],
+      "moniker_ranges": ["office-scripts", "office-scripts-async"],
       "open_to_public_contributors": true,
       "type_mapping": {
         "Conceptual": "Content",


### PR DESCRIPTION
The necessary changes for the conceptual repo to orchestrate monikers in the reference docs. See https://github.com/OfficeDev/office-scripts-docs-reference/pull/30 for the corresponding changes.