### PR TITLE
Reminder to update the flow block when changing param/return types

### DIFF
--- a/docs/develop/power-automate-integration.md
+++ b/docs/develop/power-automate-integration.md
@@ -1,7 +1,7 @@
 ---
 title: 'Run Office Scripts with Power Automate'
 description: 'How to get Office Scripts for Excel on the web working with a Power Automate workflow.'
-ms.date: 06/29/2020
+ms.date: 07/01/2020
 localization_priority: Normal
 ---
 
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 ## Getting started
 
-To begin combining Power Automate and Office Scripts, follow the tutorial [Start using scripts with Power Automate](../tutorials/excel-power-automate-manual.md). This will teach you how to create a flow that calls a simple script. After you've completed that tutorial and the [Automatically run scripts with Power Automate](../tutorials/excel-power-automate-trigger.md) tutorial, return here for detailed information about connecting Office Scripts to Power Automate flows.
+To begin combining Power Automate and Office Scripts, follow the tutorial [Start using scripts with Power Automate](../tutorials/excel-power-automate-manual.md). This will teach you how to create a flow that calls a simple script. After you've completed that tutorial and the [Automatically run scripts with automated Power Automate flows](../tutorials/excel-power-automate-trigger.md) tutorial, return here for detailed information about connecting Office Scripts to Power Automate flows.
 
 ## Excel Online (Business) connector
 
@@ -23,7 +23,16 @@ To begin combining Power Automate and Office Scripts, follow the tutorial [Start
 > [!IMPORTANT]
 > The "Run script" action gives people who use the Excel connector significant access to your workbook and its data. Additionally, there are security risks with scripts that make external API calls, as explained in [External calls from Power Automate](external-calls.md). If your admin is concerned with the exposure of highly sensitive data, they can either turn off the Excel Online connector or restrict access to Office Scripts through the [Office Scripts administrator controls](https://support.microsoft.com/office/19d3c51a-6ca2-40ab-978d-60fa49554dcf).
 
-## Passing data from Power Automate into a script
+## Data transfer in flows for scripts
+
+Power Automate lets you pass pieces of data between steps of your flow. Scripts can be configured to accept whatever types of information you need and return anything from your workbook that you want in your flow. Input for your script is specified by adding parameters to the `main` function (in addition to `workbook: ExcelScript.Workbook`). Output from the script is declared by adding a return type to `main`.
+
+> [!NOTE]
+> When you create a "Run Script" block in you flow, the accepted parameters and returned types are populated. If you change the parameters or return types of your script, you'll need to redo the "Run script" block of your flow. This ensure the data is being parsed correctly.
+
+The following sections cover the details of input and output for scripts used in Power Automate. If you'd like a hands-on approach to learning this topic, try out the [Automatically run scripts with automated Power Automate flows](../tutorials/excel-power-automate-trigger.md) tutorial or explore the [Automated task reminders](../resources/scenarios/task-reminders.md) sample scenario.
+
+### `main` Parameters: Passing data to a script
 
 All script input is specified as additional parameters for the `main` function. For example, if you wanted a script to accept a `string` that represents a name as input, you would change the `main` signature to `function main(workbook: ExcelScript.Workbook, name: string)`.
 
@@ -68,7 +77,7 @@ When adding input parameters to a script's `main` function, consider the followi
 
 10. Default parameter values are allowed (for example `async function main(workbook: ExcelScript.Workbook, Name: string = 'Jane Doe')`.
 
-## Returning data from a script back to Power Automate
+## Returning data from a script
 
 Scripts can return data from the workbook to be used as dynamic content in a Power Automate flow. As with input parameters, Power Automate places some restrictions on the return type.
 
@@ -130,7 +139,7 @@ function main(
 ## See also
 
 - [Run Office Scripts in Excel on the web with Power Automate](../tutorials/excel-power-automate-manual.md)
-- [Automatically run scripts with Power Automate](../tutorials/excel-power-automate-trigger.md)
+- [Automatically run scripts with automated Power Automate flows](../tutorials/excel-power-automate-trigger.md)
 - [Scripting fundamentals for Office Scripts in Excel on the web](scripting-fundamentals.md)
 - [Get started with Power Automate](/power-automate/getting-started)
 - [Excel Online (Business) connector reference documentation](/connectors/excelonlinebusiness/)

--- a/docs/tutorials/excel-power-automate-manual.md
+++ b/docs/tutorials/excel-power-automate-manual.md
@@ -119,4 +119,4 @@ Your flow is now ready to be run through Power Automate. You can test it using t
 
 ## Next steps
 
-Complete the [Automatically run scripts with Power Automate](excel-power-automate-trigger.md) tutorial. It teaches you how to pass data from a workflow service to your Office Script.
+Complete the [Automatically run scripts with automated Power Automate flows](excel-power-automate-trigger.md) tutorial. It teaches you how to pass data from a workflow service to your Office Script.

--- a/docs/tutorials/excel-power-automate-manual.md
+++ b/docs/tutorials/excel-power-automate-manual.md
@@ -1,7 +1,7 @@
 ---
 title: 'Start using scripts with Power Automate'
 description: 'A tutorial about using an Office Scripts in Power Automate through a manual trigger.'
-ms.date: 06/29/2020
+ms.date: 07/01/2020
 localization_priority: Priority
 ---
 

--- a/docs/tutorials/excel-power-automate-trigger.md
+++ b/docs/tutorials/excel-power-automate-trigger.md
@@ -1,11 +1,11 @@
 ---
-title: 'Automatically run scripts with Power Automate'
+title: 'Automatically run scripts with automated Power Automate flows'
 description: 'A tutorial about running Office Scripts for Excel on the web through Power Automate by using an automatic external trigger (receiving mail through Outlook).'
-ms.date: 06/29/2020
+ms.date: 07/01/2020
 localization_priority: Priority
 ---
 
-# Automatically run scripts with Power Automate (preview)
+# Automatically run scripts with automated Power Automate flows (preview)
 
 This tutorial teaches you how to use an Office Script for Excel on the web with an automated [Power Automate](https://flow.microsoft.com) workflow. Your script will automatically run each time you receive an email, recording information from the email in an Excel workbook.
 


### PR DESCRIPTION
Power Automate does not automatically update the schema for an Office Script in the connector when the script is changed. If the script has its parameters or return type changed, the flow block needs to be updated.