### PR TITLE
Add information about Worksheet.activate

### DIFF
--- a/docs/testing/power-automate-troubleshooting.md
+++ b/docs/testing/power-automate-troubleshooting.md
@@ -36,7 +36,7 @@ The following methods will throw an error and fail when called from a script in 
 
 The following methods use a default behavior, in lieu of any user's current state.
 
-| Class | Method | Power automate behavior |
+| Class | Method | Power Automate behavior |
 |--|--|--|
 | [Workbook](/javascript/api/office-scripts/excelscript/excelscript.workbook) | `getActiveWorksheet` | Returns either the first worksheet in the workbook or the worksheet currently activated by the `Worksheet.activate` method. |
 | [Worksheet](/javascript/api/office-scripts/excelscript/excelscript.worksheet) | `activate` | Marks the worksheet as the active worksheet for purposes of `Workbook.getActiveWorksheet`. |

--- a/docs/testing/power-automate-troubleshooting.md
+++ b/docs/testing/power-automate-troubleshooting.md
@@ -1,7 +1,7 @@
 ---
 title: 'Troubleshooting information for Power Automate with Office Scripts'
 description: 'Tips, platform information, and known issues with the integration between Office Scripts and Power Automate.'
-ms.date: 12/29/2020
+ms.date: 01/14/2021
 localization_priority: Normal
 ---
 
@@ -31,7 +31,6 @@ The following methods will throw an error and fail when called from a script in 
 | [Workbook](/javascript/api/office-scripts/excelscript/excelscript.workbook) | `getActiveSlicer` |
 | [Workbook](/javascript/api/office-scripts/excelscript/excelscript.workbook) | `getSelectedRange` |
 | [Workbook](/javascript/api/office-scripts/excelscript/excelscript.workbook) | `getSelectedRanges` |
-| [Worksheet](/javascript/api/office-scripts/excelscript/excelscript.worksheet) | `activate` |
 
 ### Script methods with a default behavior in Power Automate flows
 
@@ -39,7 +38,8 @@ The following methods use a default behavior, in lieu of any user's current stat
 
 | Class | Method | Power automate behavior |
 |--|--|--|
-| [Workbook](/javascript/api/office-scripts/excelscript/excelscript.workbook) | `getActiveWorksheet` | Returns the first worksheet in the workbook. |
+| [Workbook](/javascript/api/office-scripts/excelscript/excelscript.workbook) | `getActiveWorksheet` | Returns either the first worksheet in the workbook or the worksheet currently activated by the `Worksheet.activate` method. |
+| [Worksheet](/javascript/api/office-scripts/excelscript/excelscript.worksheet) | `activate` | Marks the worksheet as the active worksheet for purposes of `Workbook.getActiveWorksheet`. |
 
 ## Select workbooks with the file browser control
 


### PR DESCRIPTION
The `activate` method works in Power Automate, but does not have the typical UI-centric effect it's in-client usage would. 