### PR TITLE
Adding further troubleshooting advice in the tutorial

### DIFF
--- a/docs/tutorials/excel-tutorial.md
+++ b/docs/tutorials/excel-tutorial.md
@@ -30,7 +30,7 @@ First, we'll need some data and a small starting script.
     |Limes |600 |500 |
     |Grapefruits |900 |700 |
 
-3. Open the **Automate** tab. If you do not see the **Automate** tab, check the ribbon overflow by pressing the drop-down arrow. If it is still not there, follow the advice in the article [Troubleshoot Office Scripts](../testing/troubleshooting.md#automate-tab-not-appearing-or-office-scripts-unavailable).
+3. Open the **Automate** tab. If you don't see the **Automate** tab, check the ribbon overflow by pressing the drop-down arrow. If it's still not there, follow the advice in the article [Troubleshoot Office Scripts](../testing/troubleshooting.md#automate-tab-not-appearing-or-office-scripts-unavailable).
 4. Press the **Record Actions** button.
 5. Select cells **A2:C2** (the "Oranges" row) and set the fill color to orange.
 6. Stop the recording by pressing the **Stop** button.

--- a/docs/tutorials/excel-tutorial.md
+++ b/docs/tutorials/excel-tutorial.md
@@ -1,7 +1,7 @@
 ---
 title: 'Record, edit, and create Office Scripts in Excel on the web'
 description: 'A tutorial about the basics of Office Scripts, including recording scripts with the Action Recorder and writing data to a workbook.'
-ms.date: 05/17/2021
+ms.date: 05/23/2021
 localization_priority: Priority
 ---
 
@@ -30,7 +30,7 @@ First, we'll need some data and a small starting script.
     |Limes |600 |500 |
     |Grapefruits |900 |700 |
 
-3. Open the **Automate** tab. If you do not see the **Automate** tab, check the ribbon overflow by pressing the drop-down arrow.
+3. Open the **Automate** tab. If you do not see the **Automate** tab, check the ribbon overflow by pressing the drop-down arrow. If it is still not there, follow the advice in the article [Troubleshoot Office Scripts](../testing/troubleshooting.md#automate-tab-not-appearing-or-office-scripts-unavailable).
 4. Press the **Record Actions** button.
 5. Select cells **A2:C2** (the "Oranges" row) and set the fill color to orange.
 6. Stop the recording by pressing the **Stop** button.


### PR DESCRIPTION
I'm adding this line to help ease a user's frustration if they start the tutorial without having the Automate tab accessible. I don't think it detracts from the tutorial, but I'm open to feedback.