### PR TITLE
add link to dev portal

### DIFF
--- a/docs/develop/scripting-fundamentals.md
+++ b/docs/develop/scripting-fundamentals.md
@@ -316,9 +316,9 @@ The [Office Scripts API reference documentation](/javascript/api/office-scripts/
 
 ## See also
 
-- [Office Scripts Dev Center](https://developer.microsoft.com/office-scripts)
 - [Record, edit, and create Office Scripts in Excel on the web](../tutorials/excel-tutorial.md)
 - [Read workbook data with Office Scripts in Excel on the web](../tutorials/excel-read-tutorial.md)
 - [Office Scripts API reference](/javascript/api/office-scripts/overview)
 - [Using built-in JavaScript objects in Office Scripts](javascript-objects.md)
 - [Best practices in Office Scripts](best-practices.md)
+- [Office Scripts Dev Center](https://developer.microsoft.com/office-scripts)

--- a/docs/develop/scripting-fundamentals.md
+++ b/docs/develop/scripting-fundamentals.md
@@ -316,6 +316,7 @@ The [Office Scripts API reference documentation](/javascript/api/office-scripts/
 
 ## See also
 
+- [Office Scripts Dev Center](https://developer.microsoft.com/office-scripts)
 - [Record, edit, and create Office Scripts in Excel on the web](../tutorials/excel-tutorial.md)
 - [Read workbook data with Office Scripts in Excel on the web](../tutorials/excel-read-tutorial.md)
 - [Office Scripts API reference](/javascript/api/office-scripts/overview)

--- a/docs/index.md
+++ b/docs/index.md
@@ -124,11 +124,11 @@ Use Office Scripts in Excel on the web to automate your common tasks. Explore th
                 <div class="card">
                     <div class="cardImageOuter">
                         <div class="cardImage">
-                            <a href="https://docs.microsoft.com/answers/topics/office-scripts-excel-dev.html" target="_blank"><img src="images/index-landing-page/i_support.svg" alt="API questions" /></a>
+                            <a href="/answers/topics/office-scripts-excel-dev.html" target="_blank"><img src="images/index-landing-page/i_support.svg" alt="API questions" /></a>
                         </div>
                     </div>
                     <div class="cardText">
-                        <a href="https://docs.microsoft.com/answers/topics/office-scripts-excel-dev.html" target="_blank"><h3>Ask questions</h3></a>
+                        <a href="/answers/topics/office-scripts-excel-dev.html" target="_blank"><h3>Ask questions</h3></a>
                     </div>
                 </div>
             </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -124,11 +124,11 @@ Use Office Scripts in Excel on the web to automate your common tasks. Explore th
                 <div class="card">
                     <div class="cardImageOuter">
                         <div class="cardImage">
-                            <a href="https://stackoverflow.com/questions/tagged/office-scripts" target="_blank"><img src="images/index-landing-page/i_support.svg" alt="API questions" /></a>
+                            <a href="https://docs.microsoft.com/answers/topics/office-scripts-excel-dev.html" target="_blank"><img src="images/index-landing-page/i_support.svg" alt="API questions" /></a>
                         </div>
                     </div>
                     <div class="cardText">
-                        <a href="https://stackoverflow.com/questions/tagged/office-scripts" target="_blank"><h3>Ask questions</h3></a>
+                        <a href="https://docs.microsoft.com/answers/topics/office-scripts-excel-dev.html" target="_blank"><h3>Ask questions</h3></a>
                     </div>
                 </div>
             </div>

--- a/docs/overview/excel.md
+++ b/docs/overview/excel.md
@@ -1,7 +1,7 @@
 ---
 title: 'Office Scripts in Excel on the web'
 description: 'A brief introduction to the Action Recorder and Code Editor for Office Scripts.'
-ms.date: 05/24/2021
+ms.date: 07/04/2021
 localization_priority: Priority
 ---
 
@@ -78,10 +78,11 @@ Complete the [Office Scripts in Excel on the web tutorial](../tutorials/excel-tu
 
 ## See also
 
-- [Office Scripts Dev Center](https://developer.microsoft.com/office-scripts)
 - [Scripting fundamentals for Office Scripts in Excel on the web](../develop/scripting-fundamentals.md)
 - [Office Scripts API reference](/javascript/api/office-scripts/overview)
 - [Troubleshooting Office Scripts](../testing/troubleshooting.md)
 - [Office Scripts settings in M365](https://support.office.com/article/office-scripts-settings-in-m365-19d3c51a-6ca2-40ab-978d-60fa49554dcf)
 - [Introduction to Office Scripts in Excel (on support.office.com)](https://support.office.com/article/introduction-to-office-scripts-in-excel-9fbe283d-adb8-4f13-a75b-a81c6baf163a)
 - [Sharing Office Scripts in Excel for the Web](https://support.microsoft.com/office/sharing-office-scripts-in-excel-for-the-web-226eddbc-3a44-4540-acfe-fccda3d1122b)
+- [Office Scripts Dev Center](https://developer.microsoft.com/office-scripts)
+

--- a/docs/overview/excel.md
+++ b/docs/overview/excel.md
@@ -78,6 +78,7 @@ Complete the [Office Scripts in Excel on the web tutorial](../tutorials/excel-tu
 
 ## See also
 
+- [Office Scripts Dev Center](https://developer.microsoft.com/office-scripts)
 - [Scripting fundamentals for Office Scripts in Excel on the web](../develop/scripting-fundamentals.md)
 - [Office Scripts API reference](/javascript/api/office-scripts/overview)
 - [Troubleshooting Office Scripts](../testing/troubleshooting.md)


### PR DESCRIPTION
Hi @AlexJerabek, I noted there were no links to the Office Scripts dev portal in the docs so I added a couple. Let me know if there are other "See also" sections or other places in the docs we can add the link:

- [Office Scripts Dev Center](https://developer.microsoft.com/office-scripts)

Also, changed link from Stack Overflow to Microsoft Q&A office-scripts-excel-dev tag. 