### PR TITLE
[typescript] (Restrictions) Clarifying union type support

### DIFF
--- a/docs/develop/typescript-restrictions.md
+++ b/docs/develop/typescript-restrictions.md
@@ -1,7 +1,7 @@
 ---
 title: 'TypeScript restrictions in Office Scripts'
 description: 'The specifics of the TypeScript compiler and linter used by the Office Scripts Code Editor.'
-ms.date: 05/24/2021
+ms.date: 07/09/2021
 localization_priority: Normal
 ---
 
@@ -75,6 +75,10 @@ let filteredArray = myArray.filter((x) => {
   });
 */
 ```
+
+## Unions of `ExcelScript` types are not supported
+
+
 
 ## Performance warnings
 

--- a/docs/develop/typescript-restrictions.md
+++ b/docs/develop/typescript-restrictions.md
@@ -1,7 +1,7 @@
 ---
 title: 'TypeScript restrictions in Office Scripts'
 description: 'The specifics of the TypeScript compiler and linter used by the Office Scripts Code Editor.'
-ms.date: 07/09/2021
+ms.date: 07/14/2021
 localization_priority: Normal
 ---
 
@@ -76,9 +76,30 @@ let filteredArray = myArray.filter((x) => {
 */
 ```
 
-## Unions of `ExcelScript` types are not supported
+## Unions of `ExcelScript` types and user-defined types aren't supported
 
+Office Scripts are converted at runtime from synchronous to asynchronous code blocks. The communication with the workbook through [Promises](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise) is hidden from the script creator. This conversion doesn't support [union types](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#union-types) that include `ExcelScript` types and user-defined types.
 
+The following code sample shows an unsupported union between `ExcelScript.Table` and a custom `MyTable` interface.
+
+```TypeScript
+function main(workbook: ExcelScript.Workbook) {
+  const selectedSheet = workbook.getActiveWorksheet();
+
+  // This union is not supported.
+  const tableOrMyTable: ExcelScript.Table | MyTable = selectedSheet.getTables()[0];
+
+  // getName returns a Promise that can't be resolved by the script.
+  const name = tableOrMyTable.getName();
+
+  // This logs "{}" instead of the table name.
+  console.log(name);
+}
+
+interface MyTable {
+  getName(): string
+}
+```
 
 ## Performance warnings
 

--- a/docs/develop/typescript-restrictions.md
+++ b/docs/develop/typescript-restrictions.md
@@ -78,7 +78,7 @@ let filteredArray = myArray.filter((x) => {
 
 ## Unions of `ExcelScript` types and user-defined types aren't supported
 
-Office Scripts are converted at runtime from synchronous to asynchronous code blocks. The communication with the workbook through [Promises](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise) is hidden from the script creator. This conversion doesn't support [union types](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#union-types) that include `ExcelScript` types and user-defined types.
+Office Scripts are converted at runtime from synchronous to asynchronous code blocks. The communication with the workbook through [Promises](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise) is hidden from the script creator. This conversion doesn't support [union types](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#union-types) that include `ExcelScript` types and user-defined types. In that case, the `Promise` is returned to the script, but the Office Script complier doesn't expect it and the script creator can't interact with the `Promise`.
 
 The following code sample shows an unsupported union between `ExcelScript.Table` and a custom `MyTable` interface.
 

--- a/docs/develop/typescript-restrictions.md
+++ b/docs/develop/typescript-restrictions.md
@@ -78,7 +78,7 @@ let filteredArray = myArray.filter((x) => {
 
 ## Unions of `ExcelScript` types and user-defined types aren't supported
 
-Office Scripts are converted at runtime from synchronous to asynchronous code blocks. The communication with the workbook through [Promises](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise) is hidden from the script creator. This conversion doesn't support [union types](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#union-types) that include `ExcelScript` types and user-defined types. In that case, the `Promise` is returned to the script, but the Office Script complier doesn't expect it and the script creator can't interact with the `Promise`.
+Office Scripts are converted at runtime from synchronous to asynchronous code blocks. The communication with the workbook through [promises](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise) is hidden from the script creator. This conversion doesn't support [union types](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#union-types) that include `ExcelScript` types and user-defined types. In that case, the `Promise` is returned to the script, but the Office Script compiler doesn't expect it and the script creator can't interact with the `Promise`.
 
 The following code sample shows an unsupported union between `ExcelScript.Table` and a custom `MyTable` interface.
 
@@ -89,7 +89,7 @@ function main(workbook: ExcelScript.Workbook) {
   // This union is not supported.
   const tableOrMyTable: ExcelScript.Table | MyTable = selectedSheet.getTables()[0];
 
-  // getName returns a Promise that can't be resolved by the script.
+  // `getName` returns a promise that can't be resolved by the script.
   const name = tableOrMyTable.getName();
 
   // This logs "{}" instead of the table name.


### PR DESCRIPTION
[Internal work item](https://office.visualstudio.com/OC/_workitems/edit/5125498?src=WorkItemMention&src-action=artifact_link)

[Review site](https://review.docs.microsoft.com/en-us/office/dev/scripts/develop/typescript-restrictions?branch=AlexJ-Unions#unions-of-excelscript-types-and-user-defined-types-arent-supported)

The union of `ExcelScript` types and user-defined types is not supported. This causes problems with the transpiler that handles the async workbook communication. This PR updates the TypeScript Limitations page to include information about this problem.