### PR TITLE
[support] (Feature Requests) Remove references to UserVoice

### DIFF
--- a/Issue_Template.md
+++ b/Issue_Template.md
@@ -9,7 +9,7 @@ If your issue is not related to the Office Scripts documentation, please post it
 
 - To report an issue with the Office.js API or platform, create the issue in the OfficeDev/office-js repository (https://github.com/OfficeDev/office-js), which members of the product team monitor for customer-reported issues.
 
-- To submit a feature request for Office Scripts, post your idea to our User Voice page (https://excel.uservoice.com/forums/274580-excel-for-the-web?category_id=143439), or if the feature request already exists there, add your vote for it. Be sure to file the request under Excel for the web in the "Macros, Scripts and Add-ins" category.
+- To submit a feature request for Office Scripts, use the feedback button in the Code Editor. In the Code Editor task pane's **More options** (**...**) menu, select the **Send feedback** button to share your feature needs and other experiences.
 -->
 
 <!--- Provide a general summary of the documentation issue in the Title above -->

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If your issue is not related to the Office Scripts documentation, please post it
 
 - To ask a question about designing Office Scripts or the Office.js API that runs Office Scripts, post your question to Stack Overflow and tag it with the "office-scripts" tag (https://stackoverflow.com/questions/tagged/office-scripts).
 - To report an issue with the Office.js API, create the issue in the [OfficeDev/office-js repository](https://github.com/OfficeDev/office-js), which members of the product team monitor for customer-reported issues.
-- To submit a feature request for Office Scripts, post your idea to our [User Voice page](https://excel.uservoice.com/forums/274580-excel-for-the-web?category_id=143439), or if the feature request already exists there, add your vote for it, or if the feature request already exists there, add your vote for it. Be sure to file the request under Excel for the web in the "Macros, Scripts and Add-ins" category.
+- To submit a feature request for Office Scripts, use the feedback button in the Code Editor. In the Code Editor task pane's **More options** (**...**) menu, select the **Send feedback** button to share your feature needs and other experiences.
 
 ## Copyright
 

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -41,7 +41,7 @@
       "extendBreadcrumb": true,
       "feedback_system": "GitHub",
       "feedback_github_repo": "OfficeDev/office-scripts-docs",
-      "feedback_product_url": "https://excel.uservoice.com/forums/274580-excel-for-the-web?category_id=143439",
+      "feedback_product_url": "/office/dev/scripts/testing/troubleshooting#help-resources",
       "ms.suite": "office",
       "ms.author": "o365devx",
       "author": "o365devx",

--- a/docs/index.md
+++ b/docs/index.md
@@ -140,22 +140,6 @@ Use Office Scripts in Excel on the web to automate your common tasks. Explore th
                 <div class="card">
                     <div class="cardImageOuter">
                         <div class="cardImage">
-                            <a href="https://excel.uservoice.com/forums/274580-excel-for-the-web?category_id=143439" target="_blank"><img src="images/index-landing-page/i_feedback.svg" alt="Feature requests" /></a>
-                        </div>
-                    </div>
-                    <div class="cardText">
-                        <a href="https://excel.uservoice.com/forums/274580-excel-for-the-web?category_id=143439" target="_blank"><h3>Request features</h3></a>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </li>
-    <li>
-        <div class="cardSize">
-            <div class="cardPadding">
-                <div class="card">
-                    <div class="cardImageOuter">
-                        <div class="cardImage">
                             <a href="https://github.com/OfficeDev/office-scripts-docs/blob/master/licensing-information.md" target="_blank"><img src="images/index-landing-page/i_library.svg" alt="Licensing information" /></a>
                         </div>
                     </div>

--- a/docs/testing/troubleshooting.md
+++ b/docs/testing/troubleshooting.md
@@ -79,7 +79,7 @@ For information specific to running scripts through Power Automate, see [Trouble
 
 [Stack Overflow](https://stackoverflow.com/questions/tagged/office-scripts) is a community of developers willing to help with coding problems. Often, you'll be able to find the solution to your problem through a quick Stack Overflow search. If not, ask your question and tag it with the "office-scripts" tag. Be sure to mention you're creating an Office *Script*, not an Office *Add-in*.
 
-To submit a feature request for Office Scripts or to report an issue with the feature, use the feedback button in the Code Editor. In the Code Editor task pane's **More options** (**...**) menu, select the **Send feedback** button to share your experiences.
+To submit a feature request for Office Scripts or to report an issue with the feature, use the feedback button in the Code Editor. In the Code Editor task pane's **More options** (**...**) menu, select the **Send feedback** button to share your feature needs and other experiences.
 
 :::image type="content" source="../images/code-editor-feedback.png" alt-text="The Code Editor overflow menu with the 'Send feedback' button.":::
 

--- a/docs/testing/troubleshooting.md
+++ b/docs/testing/troubleshooting.md
@@ -1,7 +1,7 @@
 ---
 title: 'Troubleshoot Office Scripts'
 description: 'Debugging tips and techniques for Office Scripts, as well as help resources.'
-ms.date: 05/17/2021
+ms.date: 09/15/2021
 ms.localizationpriority: medium
 ---
 
@@ -79,9 +79,7 @@ For information specific to running scripts through Power Automate, see [Trouble
 
 [Stack Overflow](https://stackoverflow.com/questions/tagged/office-scripts) is a community of developers willing to help with coding problems. Often, you'll be able to find the solution to your problem through a quick Stack Overflow search. If not, ask your question and tag it with the "office-scripts" tag. Be sure to mention you're creating an Office *Script*, not an Office *Add-in*.
 
-To submit a feature request for Office Scripts, post your idea to our [User Voice page](https://excel.uservoice.com/forums/274580-excel-for-the-web?category_id=143439), or if the feature request already exists there, add your vote for it. Be sure to file the request under Excel for the web in the "Macros, Scripts and Add-ins" category.
-
-If there is a problem with the Action Recorder or Editor, please let us know. In the Code Editor task pane's **...** menu, select the **Send feedback** button to share any issues.
+To submit a feature request for Office Scripts or to report an issue with the feature, use the feedback button in the Code Editor. In the Code Editor task pane's **More options** (**...**) menu, select the **Send feedback** button to share your experiences.
 
 :::image type="content" source="../images/code-editor-feedback.png" alt-text="The Code Editor overflow menu with the 'Send feedback' button.":::
 


### PR DESCRIPTION
Fixes #397. 

The current guidance is to submit feature requests through the Code Editor's feedback button. This PR removes the obsolete UserVoice links and replaces them with guidance to use the feedback button.