### PR TITLE
Update search scope

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -38,6 +38,7 @@
     "globalMetadata": {
       "uhfHeaderId": "office-scripts",
       "searchScope": ["Office Scripts"],
+      "hideScope": true,
       "breadcrumb_path": "/office/dev/scripts/breadcrumb/toc.json",
       "extendBreadcrumb": true,
       "feedback_system": "GitHub",


### PR DESCRIPTION
Related to feature 4460765.

Per the [docs](https://review.docs.microsoft.com/en-us/help/onboard/admin/search-experience?branch=main#facets), remove hideScope setting after docs search index should have completed in a couple of days post publish.