### PR TITLE
[Power Automate] (Parameters and returns)  Addressing feedback about PA return types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ _site/
 .optemp/
 _themes*/
 _repo.*/
+.vscode/
 
 .openpublishing.buildcore.ps1

--- a/docs/develop/power-automate-integration.md
+++ b/docs/develop/power-automate-integration.md
@@ -1,7 +1,7 @@
 ---
 title: 'Run Office Scripts with Power Automate'
 description: 'How to get Office Scripts for Excel on the web working with a Power Automate workflow.'
-ms.date: 05/17/2021
+ms.date: 11/01/2021
 ms.localizationpriority: medium
 ---
 
@@ -41,17 +41,19 @@ When adding input parameters to a script's `main` function, consider the followi
 
 1. The first parameter must be of type `ExcelScript.Workbook`. Its parameter name does not matter.
 
-2. Every parameter must have a type (such as `string` or `number`).
+1. Every parameter must have a type (such as `string` or `number`).
 
-3. The basic types `string`, `number`, `boolean`, `unknown`, `object`, and `undefined` are supported.
+1. The basic types `string`, `number`, `boolean`, `unknown`, `object`, and `undefined` are supported.
 
-4. Arrays of the previously listed basic types are supported.
+1. Arrays (`[]`) of the previously listed basic types are supported.
+    > [!IMPORTANT]
+    > Please note that the object `Array<T>` is not a supported parameter type.
 
-5. Nested arrays are supported as parameters (but not as return types).
+1. Nested arrays are supported as parameters (but not as return types).
 
-6. Union types are allowed if they are a union of literals belonging to a single type (such as `"Left" | "Right"`). Unions of a supported type with undefined are also supported (such as `string | undefined`).
+1. Union types are allowed if they are a union of literals belonging to a single type (such as `"Left" | "Right"`). Unions of a supported type with undefined are also supported (such as `string | undefined`).
 
-7. Object types are allowed if they contain properties of type `string`, `number`, `boolean`, supported arrays, or other supported objects. The following example shows nested objects that are supported as parameter types:
+1. Object types are allowed if they contain properties of type `string`, `number`, `boolean`, supported arrays, or other supported objects. The following example shows nested objects that are supported as parameter types:
 
     ```TypeScript
     // Office Scripts can return an Employee object because Position only contains strings and numbers.
@@ -66,15 +68,15 @@ When adding input parameters to a script's `main` function, consider the followi
     }
     ```
 
-8. Objects must have their interface or class definition defined in the script. An object can also be defined anonymously inline, as in the following example:
+1. Objects must have their interface or class definition defined in the script. An object can also be defined anonymously inline, as in the following example:
 
     ```TypeScript
     function main(workbook: ExcelScript.Workbook): {name: string, email: string}
     ```
 
-9. Optional parameters are allowed and can be denoted as such by using the optional modifier `?` (for example, `function main(workbook: ExcelScript.Workbook, Name?: string)`).
+1. Optional parameters are allowed and can be denoted as such by using the optional modifier `?` (for example, `function main(workbook: ExcelScript.Workbook, Name?: string)`).
 
-10. Default parameter values are allowed (for example `async function main(workbook: ExcelScript.Workbook, Name: string = 'Jane Doe')`.
+1. Default parameter values are allowed (for example `async function main(workbook: ExcelScript.Workbook, Name: string = 'Jane Doe')`.
 
 ### Return data from a script
 
@@ -82,13 +84,15 @@ Scripts can return data from the workbook to be used as dynamic content in a Pow
 
 1. The basic types `string`, `number`, `boolean`, `void`, and `undefined` are supported.
 
-2. Union types used as return types follow the same restrictions as they do when used as script parameters.
+1. Union types used as return types follow the same restrictions as they do when used as script parameters.
 
-3. Array types are allowed if they are of type `string`, `number`, or `boolean`. They are also allowed if the type is a supported union or supported literal type.
+1. Array types (`[]`) are allowed if they are of type `string`, `number`, or `boolean`. They are also allowed if the type is a supported union or supported literal type.
+    > [!IMPORTANT]
+    > Please note that the object `Array<T>` is not a supported return type.
 
-4. Object types used as return types follow the same restrictions as they do when used as script parameters.
+1. Object types used as return types follow the same restrictions as they do when used as script parameters.
 
-5. Implicit typing is supported, though it must follow the same rules as a defined type.
+1. Implicit typing is supported, though it must follow the same rules as a defined type.
 
 ## Example
 

--- a/docs/testing/power-automate-troubleshooting.md
+++ b/docs/testing/power-automate-troubleshooting.md
@@ -78,7 +78,7 @@ If your script uses dates or times, there may be behavioral differences when the
 
 ## Script parameter fields or returned output not appearing in Power Automate
 
-There are two reasons that the input or output of a script are not accurately reflected in the Power Automate flow builder.
+There are two reasons that the parameters or returned data of a script is not accurately reflected in the Power Automate flow builder.
 
 - The script signature (the parameters or return value) has changed since the **Excel Business (Online)** connector was added.
 - The script signature uses unsupported types. Verify your types against the lists under the [parameters](../develop/power-automate-integration.md#main-parameters-pass-data-to-a-script) and [returns](../develop/power-automate-integration.md#return-data-from-a-script) sections of [Run Office Scripts with Power Automate](../develop/power-automate-integration.md) article.

--- a/docs/testing/power-automate-troubleshooting.md
+++ b/docs/testing/power-automate-troubleshooting.md
@@ -68,7 +68,7 @@ For more context on the Power Automate limitation and a discussion of potential 
 
 Power Automate allows users to pass arrays to connectors as a variable or as single elements in the array. The default is to pass single elements, which builds the array in the flow. For scripts or other connectors that take entire arrays as arguments, you need to press the **Switch to input entire array** button to pass the array an one complete object.
 
-:::image type="content" source="../../images/combine-worksheets-flow-3.png" alt-text="The button to switch to input an entire array in a control field input box.":::
+:::image type="content" source="../images/combine-worksheets-flow-3.png" alt-text="The button to switch to input an entire array in a control field input box.":::
 
 ## Time zone differences
 
@@ -81,7 +81,7 @@ If your script uses dates or times, there may be behavioral differences when the
 There are two reasons that the input or output of a script are not accurately reflected in the Power Automate flow builder.
 
 - The script signature (the parameters or return value) has changed since the **Excel Business (Online)** connector was added.
-- The script signature uses unsupported types. Verify your types against the lists under the [parameters](../develop/power-automate-integration.md#-main-parameters-pass-data-to-a-script) and [returns](../develop/power-automate-integration.md#return-data-from-a-script) sections of [Run Office Scripts with Power Automate](../develop/power-automate-integration.md) article.
+- The script signature uses unsupported types. Verify your types against the lists under the [parameters](../develop/power-automate-integration.md#main-parameters-pass-data-to-a-script) and [returns](../develop/power-automate-integration.md#return-data-from-a-script) sections of [Run Office Scripts with Power Automate](../develop/power-automate-integration.md) article.
 
 THe signature of a script is stored with the **Excel Business (Online)** connector when it is created. Remove the old connector and create a new one to get the latest parameters and return values for the **Run script** action.
 

--- a/docs/testing/power-automate-troubleshooting.md
+++ b/docs/testing/power-automate-troubleshooting.md
@@ -1,7 +1,7 @@
 ---
 title: 'Troubleshoot Office Scripts running in Power Automate'
 description: 'Tips, platform information, and known issues with the integration between Office Scripts and Power Automate.'
-ms.date: 05/18/2021
+ms.date: 11/01/2021
 ms.localizationpriority: medium
 ---
 
@@ -64,11 +64,26 @@ When building the **Run script** step of a Power Automate flow, you need to sele
 
 For more context on the Power Automate limitation and a discussion of potential workarounds for the dynamic selection of workbooks, see [this thread in the Microsoft Power Automate Community](https://powerusers.microsoft.com/t5/Power-Automate-Ideas/Allow-for-dynamic-quot-file-quot-value-for-excel-quot-get-a-row/idi-p/103091#).
 
+## Pass entire arrays as script parameters
+
+Power Automate allows users to pass arrays to connectors as a variable or as single elements in the array. The default is to pass single elements, which builds the array in the flow. For scripts or other connectors that take entire arrays as arguments, you need to press the **Switch to input entire array** button to pass the array an one complete object.
+
+:::image type="content" source="../../images/combine-worksheets-flow-3.png" alt-text="The button to switch to input an entire array in a control field input box.":::
+
 ## Time zone differences
 
 Excel files don't have an inherent location or timezone. Every time a user opens the workbook, their session uses that user's local timezone for date calculations. Power Automate always uses UTC.
 
 If your script uses dates or times, there may be behavioral differences when the script is tested locally versus when it is run through Power Automate. Power Automate allows you to convert, format, and adjust times. See [Working with Dates and Times inside of your flows](https://flow.microsoft.com/blog/working-with-dates-and-times/) for instructions on how to use those functions in Power Automate and [`main` Parameters: Pass data to a script](../develop/power-automate-integration.md#main-parameters-pass-data-to-a-script) to learn how to provide that time information for the script.
+
+## Script parameter fields or returned output not appearing in Power Automate
+
+There are two reasons that the input or output of a script are not accurately reflected in the Power Automate flow builder.
+
+- The script signature (the parameters or return value) has changed since the **Excel Business (Online)** connector was added.
+- The script signature uses unsupported types. Verify your types against the lists under the [parameters](../develop/power-automate-integration.md#-main-parameters-pass-data-to-a-script) and [returns](../develop/power-automate-integration.md#return-data-from-a-script) sections of [Run Office Scripts with Power Automate](../develop/power-automate-integration.md) article.
+
+THe signature of a script is stored with the **Excel Business (Online)** connector when it is created. Remove the old connector and create a new one to get the latest parameters and return values for the **Run script** action.
 
 ## See also
 

--- a/docs/testing/power-automate-troubleshooting.md
+++ b/docs/testing/power-automate-troubleshooting.md
@@ -66,7 +66,7 @@ For more context on the Power Automate limitation and a discussion of potential 
 
 ## Pass entire arrays as script parameters
 
-Power Automate allows users to pass arrays to connectors as a variable or as single elements in the array. The default is to pass single elements, which builds the array in the flow. For scripts or other connectors that take entire arrays as arguments, you need to select the **Switch to input entire array** button to pass the array as one complete object.
+Power Automate allows users to pass arrays to connectors as a variable or as single elements in the array. The default is to pass single elements, which builds the array in the flow. For scripts or other connectors that take entire arrays as arguments, you need to select the **Switch to input entire array** button to pass the array as one complete object. This button is in the upper-right corner of each array parameter input field.
 
 :::image type="content" source="../images/combine-worksheets-flow-3.png" alt-text="The button to switch to input an entire array in a control field input box.":::
 

--- a/docs/testing/power-automate-troubleshooting.md
+++ b/docs/testing/power-automate-troubleshooting.md
@@ -66,7 +66,7 @@ For more context on the Power Automate limitation and a discussion of potential 
 
 ## Pass entire arrays as script parameters
 
-Power Automate allows users to pass arrays to connectors as a variable or as single elements in the array. The default is to pass single elements, which builds the array in the flow. For scripts or other connectors that take entire arrays as arguments, you need to press the **Switch to input entire array** button to pass the array an one complete object.
+Power Automate allows users to pass arrays to connectors as a variable or as single elements in the array. The default is to pass single elements, which builds the array in the flow. For scripts or other connectors that take entire arrays as arguments, you need to select the **Switch to input entire array** button to pass the array as one complete object.
 
 :::image type="content" source="../images/combine-worksheets-flow-3.png" alt-text="The button to switch to input an entire array in a control field input box.":::
 
@@ -78,12 +78,12 @@ If your script uses dates or times, there may be behavioral differences when the
 
 ## Script parameter fields or returned output not appearing in Power Automate
 
-There are two reasons that the parameters or returned data of a script is not accurately reflected in the Power Automate flow builder.
+There are two reasons that the parameters or returned data of a script are not accurately reflected in the Power Automate flow builder.
 
 - The script signature (the parameters or return value) has changed since the **Excel Business (Online)** connector was added.
 - The script signature uses unsupported types. Verify your types against the lists under the [parameters](../develop/power-automate-integration.md#main-parameters-pass-data-to-a-script) and [returns](../develop/power-automate-integration.md#return-data-from-a-script) sections of [Run Office Scripts with Power Automate](../develop/power-automate-integration.md) article.
 
-THe signature of a script is stored with the **Excel Business (Online)** connector when it is created. Remove the old connector and create a new one to get the latest parameters and return values for the **Run script** action.
+The signature of a script is stored with the **Excel Business (Online)** connector when it is created. Remove the old connector and create a new one to get the latest parameters and return values for the **Run script** action.
 
 ## See also
 


### PR DESCRIPTION
Fixes #416.

This PR clarifies the distinction between the Array object and arrays (`x[]` versus `Array<X>`) necessary for the PA connector. It also adds some common errors to the PA troubleshooting section.

Tagging @jeremy-msft for technical accuracy and @alison-mk for content.