### PR TITLE
[typescript] (Limitations) Add limitation about constructors

### DIFF
--- a/docs/develop/typescript-restrictions.md
+++ b/docs/develop/typescript-restrictions.md
@@ -1,7 +1,7 @@
 ---
 title: 'TypeScript restrictions in Office Scripts'
 description: 'The specifics of the TypeScript compiler and linter used by the Office Scripts Code Editor.'
-ms.date: 07/14/2021
+ms.date: 11/09/2021
 ms.localizationpriority: medium
 ---
 
@@ -98,6 +98,25 @@ function main(workbook: ExcelScript.Workbook) {
 
 interface MyTable {
   getName(): string
+}
+```
+
+## Constructors don't support Office Scripts APIs and `console` statements
+
+`console` statements and many Office Scripts APIs require synchronization with the Excel workbook. These synchronizations use `await` statements in compiled runtime version of the script. `await` is not supported in constructors. If you need classes with constructors, avoid using Office Scripts APIs or `console` statements in those code blocks.
+
+The following code sample demonstrates this scenario. It generates an error that says "failed to load \[code\] \[library\]".
+
+```TypeScript
+function main(workbook: ExcelScript.Workbook) {
+  class MyClass {
+    constructor() {
+      // Console statements and Office Scripts APIs aren't supported in constructors.
+      console.log("This won't print.");
+    }
+  }
+
+  let test = new MyClass();
 }
 ```
 

--- a/docs/develop/typescript-restrictions.md
+++ b/docs/develop/typescript-restrictions.md
@@ -105,7 +105,7 @@ interface MyTable {
 
 `console` statements and many Office Scripts APIs require synchronization with the Excel workbook. These synchronizations use `await` statements in compiled runtime version of the script. `await` is not supported in [constructors](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/constructor). If you need classes with constructors, avoid using Office Scripts APIs or `console` statements in those code blocks.
 
-The following code sample demonstrates this scenario. It generates an error that says "failed to load \[code\] \[library\]".
+The following code sample demonstrates this scenario. It generates an error that says `failed to load [code] [library]`.
 
 ```TypeScript
 function main(workbook: ExcelScript.Workbook) {

--- a/docs/develop/typescript-restrictions.md
+++ b/docs/develop/typescript-restrictions.md
@@ -103,7 +103,7 @@ interface MyTable {
 
 ## Constructors don't support Office Scripts APIs and `console` statements
 
-`console` statements and many Office Scripts APIs require synchronization with the Excel workbook. These synchronizations use `await` statements in compiled runtime version of the script. `await` is not supported in constructors. If you need classes with constructors, avoid using Office Scripts APIs or `console` statements in those code blocks.
+`console` statements and many Office Scripts APIs require synchronization with the Excel workbook. These synchronizations use `await` statements in compiled runtime version of the script. `await` is not supported in [constructors](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/constructor). If you need classes with constructors, avoid using Office Scripts APIs or `console` statements in those code blocks.
 
 The following code sample demonstrates this scenario. It generates an error that says "failed to load \[code\] \[library\]".
 


### PR DESCRIPTION
[Internal work item](https://office.visualstudio.com/OC/_workitems/edit/5165026/)

APIs that use async/await statements in the transpiled script can't be called in constructors. This PR documents that limitation.