### PR TITLE
[ux] (Code Editor) Removing references to the Code Editor feedback button

### DIFF
--- a/Issue_Template.md
+++ b/Issue_Template.md
@@ -8,8 +8,6 @@ If your issue is not related to the Office Scripts documentation, please post it
 - To ask a question about designing Office Scripts or the Office.js API that runs Office Scripts, post your question to Stack Overflow and tag it with the "office-scripts" tag (https://stackoverflow.com/questions/tagged/office-scripts).
 
 - To report an issue with the Office.js API or platform, create the issue in the OfficeDev/office-js repository (https://github.com/OfficeDev/office-js), which members of the product team monitor for customer-reported issues.
-
-- To submit a feature request for Office Scripts, use the feedback button in the Code Editor. In the Code Editor task pane's **More options (…)** menu, select the **Send feedback** button to share your feature needs and other experiences.
 -->
 
 <!--- Provide a general summary of the documentation issue in the Title above -->

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ If your issue is not related to the Office Scripts documentation, please post it
 
 - To ask a question about designing Office Scripts or the Office.js API that runs Office Scripts, post your question to Stack Overflow and tag it with the "office-scripts" tag (https://stackoverflow.com/questions/tagged/office-scripts).
 - To report an issue with the Office.js API, create the issue in the [OfficeDev/office-js repository](https://github.com/OfficeDev/office-js), which members of the product team monitor for customer-reported issues.
-- To submit a feature request for Office Scripts, use the feedback button in the Code Editor. In the Code Editor task pane's **More options (…)** menu, select the **Send feedback** button to share your feature needs and other experiences.
 
 ## Copyright
 

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -42,7 +42,7 @@
       "extendBreadcrumb": true,
       "feedback_system": "GitHub",
       "feedback_github_repo": "OfficeDev/office-scripts-docs",
-      "feedback_product_url": "/office/dev/scripts/testing/troubleshooting#help-resources",
+      "feedback_product_url": "/answers/topics/312419/office-scripts-excel-dev.html",
       "ms.suite": "office",
       "ms.author": "o365devx",
       "author": "o365devx",

--- a/docs/testing/troubleshooting.md
+++ b/docs/testing/troubleshooting.md
@@ -1,7 +1,7 @@
 ---
 title: 'Troubleshoot Office Scripts'
 description: 'Debugging tips and techniques for Office Scripts, as well as help resources.'
-ms.date: 09/15/2021
+ms.date: 11/11/2021
 ms.localizationpriority: medium
 ---
 
@@ -78,10 +78,6 @@ For information specific to running scripts through Power Automate, see [Trouble
 ## Help resources
 
 [Stack Overflow](https://stackoverflow.com/questions/tagged/office-scripts) is a community of developers willing to help with coding problems. Often, you'll be able to find the solution to your problem through a quick Stack Overflow search. If not, ask your question and tag it with the "office-scripts" tag. Be sure to mention you're creating an Office *Script*, not an Office *Add-in*.
-
-To submit a feature request for Office Scripts or to report an issue with the feature, use the feedback button in the Code Editor. In the Code Editor task pane's  **More options (…)** menu, select the **Send feedback** button to share your feature needs and other experiences.
-
-:::image type="content" source="../images/code-editor-feedback.png" alt-text="The Code Editor overflow menu with the 'Send feedback' button.":::
 
 ## See also
 


### PR DESCRIPTION
Based on [this internal Code Editor change](https://office.visualstudio.com/OC/_git/MakerCodeEditor/pullrequest/1077863), the **Send Feedback** button has been removed. This PR updates the docs accordingly.

@nancy-wang, do we have an alternate way to capture feedback and feature requests?