### PR TITLE
[samples] (Scenarios) Fix implicit any usage in the Analyze web downloads sample

### DIFF
--- a/docs/resources/scenarios/analyze-web-downloads.md
+++ b/docs/resources/scenarios/analyze-web-downloads.md
@@ -43,28 +43,28 @@ You'll develop a script that analyzes weekly downloads data in the active worksh
         console.log("The script expects a summary table named \"Table1\". Please download the correct template and try again.");
         return;
       }
-  
+
       // Get the current worksheet.
       let currentWorksheet = workbook.getActiveWorksheet();
       if (currentWorksheet.getName().toLocaleLowerCase().indexOf("week") !== 0) {
         console.log("Please switch worksheet to one of the weekly data sheets and try again.")
         return;
       }
-  
+
       // Get the values of the active range of the active worksheet.
       let logRange = currentWorksheet.getUsedRange();
-  
+
       if (logRange.getColumnCount() !== 8) {
         console.log(`Verify that you are on the correct worksheet. Either the week's data has been already processed or the content is incorrect. The following columns are expected: ${[
-            "Time Stamp", "IP Address", "kilobytes", "user agent code", "milliseconds", "Request", "Results", "Referrer"
+          "Time Stamp", "IP Address", "kilobytes", "user agent code", "milliseconds", "Request", "Results", "Referrer"
         ]}`);
         return;
       }
       // Get the range that will contain TRUE/FALSE if the IP address is from the United States (US).
       let isUSColumn = logRange
-          .getLastColumn()
-          .getOffsetRange(0, 1);
-  
+        .getLastColumn()
+        .getOffsetRange(0, 1);
+
       // Get the values of all the US IP addresses.
       let ipRange = workbook.getWorksheet("USIPAddresses").getUsedRange();
       let ipRangeValues = ipRange.getValues() as number[][];
@@ -72,10 +72,10 @@ You'll develop a script that analyzes weekly downloads data in the active worksh
       // Remove the first row.
       let topRow = logRangeValues.shift();
       console.log(`Analyzing ${logRangeValues.length} entries.`);
-  
+
       // Create a new array to contain the boolean representing if this is a US IP address.
-      let newCol = [];
-  
+      let newCol: (boolean | string)[][] = [];
+
       // Go through each row in worksheet and add Boolean.
       for (let i = 0; i < logRangeValues.length; i++) {
         let curRowIP = logRangeValues[i][1];
@@ -85,33 +85,33 @@ You'll develop a script that analyzes weekly downloads data in the active worksh
           newCol.push([false]);
         }
       }
-  
+
       // Remove the empty column header and add proper heading.
       newCol = [["Is US IP"], ...newCol];
-  
+
       // Write the result to the spreadsheet.
       console.log(`Adding column to indicate whether IP belongs to US region or not at address: ${isUSColumn.getAddress()}`);
       console.log(newCol.length);
       console.log(newCol);
       isUSColumn.setValues(newCol);
-  
+
       // Call the local function to add summary data to the worksheet.
       addSummaryData();
-  
+
       // Call the local function to apply conditional formatting.
       applyConditionalFormatting(isUSColumn);
-  
+
       // Autofit columns.
       currentWorksheet.getUsedRange().getFormat().autofitColumns();
-  
+
       // Get the calculated summary data.
       let summaryRangeValues = currentWorksheet.getRange("J2:M2").getValues();
-  
+
       // Add the corresponding row to the summary table.
       summaryTable.addRow(null, summaryRangeValues[0]);
       console.log("Complete.");
       return;
-  
+
       /**
        * A function to add summary data on the worksheet.
         */
@@ -119,9 +119,9 @@ You'll develop a script that analyzes weekly downloads data in the active worksh
         // Add a summary row and table.
         let summaryHeader = [["Year", "Week", "US", "Other"]];
         let countTrueFormula =
-            "=COUNTIF(" + isUSColumn.getAddress() + ', "=TRUE")/' + (newCol.length - 1);
+          "=COUNTIF(" + isUSColumn.getAddress() + ', "=TRUE")/' + (newCol.length - 1);
         let countFalseFormula =
-            "=COUNTIF(" + isUSColumn.getAddress() + ', "=FALSE")/' + (newCol.length - 1);
+          "=COUNTIF(" + isUSColumn.getAddress() + ', "=FALSE")/' + (newCol.length - 1);
 
         let summaryContent = [
           [
@@ -143,8 +143,8 @@ You'll develop a script that analyzes weekly downloads data in the active worksh
 
         let formats = [[".000", ".000"]];
         summaryContentRow
-            .getOffsetRange(0, 2)
-            .getResizedRange(0, -2).setNumberFormats(formats);
+          .getOffsetRange(0, 2)
+          .getResizedRange(0, -2).setNumberFormats(formats);
       }
     }
     /**
@@ -153,21 +153,21 @@ You'll develop a script that analyzes weekly downloads data in the active worksh
     function applyConditionalFormatting(isUSColumn: ExcelScript.Range) {
       // Add conditional formatting to the new column.
       let conditionalFormatTrue = isUSColumn.addConditionalFormat(
-          ExcelScript.ConditionalFormatType.cellValue
+        ExcelScript.ConditionalFormatType.cellValue
       );
       let conditionalFormatFalse = isUSColumn.addConditionalFormat(
-          ExcelScript.ConditionalFormatType.cellValue
+        ExcelScript.ConditionalFormatType.cellValue
       );
       // Set TRUE to light blue and FALSE to light orange.
       conditionalFormatTrue.getCellValue().getFormat().getFill().setColor("#8FA8DB");
       conditionalFormatTrue.getCellValue().setRule({
-          formula1: "=TRUE",
-          operator: ExcelScript.ConditionalCellValueOperator.equalTo
+        formula1: "=TRUE",
+        operator: ExcelScript.ConditionalCellValueOperator.equalTo
       });
       conditionalFormatFalse.getCellValue().getFormat().getFill().setColor("#F8CCAD");
       conditionalFormatFalse.getCellValue().setRule({
-          formula1: "=FALSE",
-          operator: ExcelScript.ConditionalCellValueOperator.equalTo
+        formula1: "=FALSE",
+        operator: ExcelScript.ConditionalCellValueOperator.equalTo
       });
     }
     /**
@@ -177,14 +177,14 @@ You'll develop a script that analyzes weekly downloads data in the active worksh
     function ipAddressToInteger(ipAddress: string): number {
       // Split the IP address into octets.
       let octets = ipAddress.split(".");
-  
+
       // Create a number for each octet and do the math to create the integer value of the IP address.
       let fullNum =
-          // Define an arbitrary number for the last octet.
-          111 +
-          parseInt(octets[2]) * 256 +
-          parseInt(octets[1]) * 65536 +
-          parseInt(octets[0]) * 16777216;
+        // Define an arbitrary number for the last octet.
+        111 +
+        parseInt(octets[2]) * 256 +
+        parseInt(octets[1]) * 65536 +
+        parseInt(octets[0]) * 16777216;
       return fullNum;
     }
     /**


### PR DESCRIPTION
Fixes #436.

When [this restriction](https://docs.microsoft.com/en-us/office/dev/scripts/develop/typescript-restrictions#no-any-type-in-office-scripts) was added to Office Scripts, the sample in question was not updated to match.

Some of the code spacing is also updated to reflect the current spacing standards in the Code Editor.