### PR TITLE
[script buttons] (Rollout status) Removing preview text for script buttons

### DIFF
--- a/docs/overview/excel.md
+++ b/docs/overview/excel.md
@@ -2,7 +2,7 @@
 title: 'Office Scripts in Excel on the web'
 description: 'A brief introduction to the Action Recorder and Code Editor for Office Scripts.'
 ms.topic: overview
-ms.date: 02/04/2022
+ms.date: 02/08/2022
 ms.localizationpriority: high
 ---
 
@@ -74,8 +74,6 @@ For more details about sharing and unsharing scripts, see [Sharing Office Script
 
 ### Create script buttons
 
-[!INCLUDE [Rollout information](../includes/rollout-note.md)]
-
 :::image type="content" source="../images/run-from-button.png" alt-text="A button in the worksheet that runs a script when clicked.":::
 
 Help your colleagues find and run your scripts by adding script buttons to a workbook. With any script, go to the **More options (…)** menu in either the script's Details page or the Code Editor's task pane and select **Add button**. This creates a button in the workbook that runs the associated script when selected. It also shares the script with the workbook, so everyone with write permissions to the workbook can use your helpful automation.
@@ -87,7 +85,7 @@ The following screenshot shows the script Details page for a script titled **Cre
 These script buttons also work on Windows. Create the button in Excel on the web and users on Windows can run your script with the press of a button. Please note that only running the button is supported on Windows. If you need to edit the script, you need to do that through the web application.
 
 > [!NOTE]
-> To use this feature on Windows, you need a copy of Excel connected to a Microsoft 365 subscription. Unsupported platforms or older Office versions display the shape used for the script button, but it's not clickable.
+> This feature is being rolled out to users with a Microsoft 365 subscription and is not available to everyone. It's slowly released to larger numbers of users to ensure that it's working as expected. This feature is subject to change based on your feedback. Unsupported platforms or Office versions without the feature will display the shape used for the script button, but the button won't be clickable.
 
 To stop sharing a script through a button, go to the **More options (…)** menu in the script's Details page and select **Stop Sharing**. This removes all the buttons that run the script. Deleting a single button removes the script from that one button, even if the operation is undone or the button is cut and pasted.
 


### PR DESCRIPTION
This PR removes the "preview" markings for the script button feature. It does leave the Windows rollout information in place, since that is not at 100% yet.