### PR TITLE
[excel] (Task pane) Standardize capitalization for script details page

### DIFF
--- a/docs/develop/script-buttons.md
+++ b/docs/develop/script-buttons.md
@@ -16,13 +16,13 @@ Help your colleagues find and run your scripts by adding script buttons to a wor
 
 With any script, go to the **More options (…)** menu in either the script's details page or the Code Editor's task pane and select **Add button**. This creates a button in the workbook that runs the associated script when selected. It also shares the script with the workbook, so everyone with write permissions to the workbook can use your helpful automation.
 
-The following screenshot shows the script Details page for a script titled **Create PivotTable** and has the **Add button** option within the **More options (…)** menu highlighted.
+The following screenshot shows the script details page for a script titled **Create PivotTable** and has the **Add button** option within the **More options (…)** menu highlighted.
 
-:::image type="content" source="../images/add-button.png" alt-text="The 'Add button' option in the script Details page menu.":::
+:::image type="content" source="../images/add-button.png" alt-text="The 'Add button' option in the script details page menu.":::
 
 ## Remove script buttons
 
-To stop sharing a script through a button, go to the **More options (…)** menu in the script's Details page and select **Stop sharing**. This removes all the buttons that run the script. Deleting a single button removes the script from that one button, even if the operation is undone or the button is cut and pasted.
+To stop sharing a script through a button, go to the **More options (…)** menu in the script details page and select **Stop sharing**. This removes all the buttons that run the script. Deleting a single button removes the script from that one button, even if the operation is undone or the button is cut and pasted.
 
 ## Script buttons on Excel for Windows
 

--- a/docs/overview/excel.md
+++ b/docs/overview/excel.md
@@ -65,7 +65,7 @@ Our [tutorials](../tutorials/excel-tutorial.md) provide a guided and structured 
 
 Office Scripts can be shared with other users of an Excel workbook. When you share a script in a shared workbook, everyone with access to the workbook can also view and run your script. For more details about sharing and unsharing scripts, see [Sharing Office Scripts in Excel for the Web](https://support.microsoft.com/office/226eddbc-3a44-4540-acfe-fccda3d1122b).
 
-:::image type="content" source="../images/script-sharing.png" alt-text="The script Details page showing the 'Share with others in this workbook' option.":::
+:::image type="content" source="../images/script-sharing.png" alt-text="The script details page showing the 'Share with others in this workbook' option.":::
 
 Add buttons that run scripts to help your colleagues discover your valuable solutions. Learn more about script buttons in [Run Office Scripts with buttons](../develop/script-buttons.md).
 


### PR DESCRIPTION
There's not a formal title on the page that loads in the task pane when you select a script. Based on that, the term "details" shouldn't be capitalized.

![image](https://user-images.githubusercontent.com/38896772/166068255-4470632f-9b9c-4089-9203-3492499e3c93.png)
