### PR TITLE
[excel] (Platform) Generalizing language to better account for Script Buttons

### DIFF
--- a/Issue_Template.md
+++ b/Issue_Template.md
@@ -1,5 +1,5 @@
 <!---
-Welcome to the documentation repository for Office Scripts in Excel on the web.
+Welcome to the documentation repository for Office Scripts.
 
 To report an issue with the Office Scripts documentation, please provide the article URL and describe the issue below. Alternatively, if you want to submit a pull request with your recommended documentation changes, we will review your contributions and update our documentation accordingly.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Office Scripts in Excel on the web documentation
+# Office Scripts documentation
 
 Welcome to the Office Scripts documentation repository. In this repo, you can find the documentation source files for Office Scripts tutorials and how-to guides. For the best experience, we recommend you view this content on [docs.microsoft.com](https://docs.microsoft.com/office/dev/scripts).
 
-> **Note**: You can find the reference documentation source files for the Office Scripts API in the [office-scripts-docs-reference](https://github.com/OfficeDev/office-scripts-docs-reference) repository. These APIs contain all the potential Excel operations for your scripts.
+> **Note**: You can find the reference documentation source files for the Office Scripts API in the [office-scripts-docs-reference](https://github.com/OfficeDev/office-scripts-docs-reference) repository. These APIs contain all the potential operations for your scripts.
 
 ## Give us your feedback
 

--- a/docs/develop/power-automate-integration.md
+++ b/docs/develop/power-automate-integration.md
@@ -109,7 +109,7 @@ function main(
 
 ## See also
 
-- [Run Office Scripts in Excel on the web with Power Automate](../tutorials/excel-power-automate-manual.md)
+- [Run Office Scripts in Excel with Power Automate](../tutorials/excel-power-automate-manual.md)
 - [Pass data to scripts in an automatically-run Power Automate flow](../tutorials/excel-power-automate-trigger.md)
 - [Return data from a script to an automatically-run Power Automate flow](../tutorials/excel-power-automate-returns.md)
 - [Troubleshooting information for Power Automate with Office Scripts](../testing/power-automate-troubleshooting.md)

--- a/docs/develop/power-automate-integration.md
+++ b/docs/develop/power-automate-integration.md
@@ -109,7 +109,7 @@ function main(
 
 ## See also
 
-- [Run Office Scripts in Excel with Power Automate](../tutorials/excel-power-automate-manual.md)
+- [Call scripts from a manual Power Automate flow](../tutorials/excel-power-automate-manual.md)
 - [Pass data to scripts in an automatically-run Power Automate flow](../tutorials/excel-power-automate-trigger.md)
 - [Return data from a script to an automatically-run Power Automate flow](../tutorials/excel-power-automate-returns.md)
 - [Troubleshooting information for Power Automate with Office Scripts](../testing/power-automate-troubleshooting.md)

--- a/docs/develop/script-buttons.md
+++ b/docs/develop/script-buttons.md
@@ -24,8 +24,11 @@ The following screenshot shows the script details page for a script titled **Cre
 
 To stop sharing a script through a button, go to the **More options (…)** menu in the script details page and select **Stop sharing**. This removes all the buttons that run the script. Deleting a single button removes the script from that one button, even if the operation is undone or the button is cut and pasted.
 
-## Script buttons on Excel for Windows
+## Script buttons with Excel on Windows
 
 These script buttons also work on Windows. Create the button in Excel on the web and users on Windows can run your script with the click of a button. Please note that you cannot edit scripts in Excel on Windows. You can only edit scripts in Excel on the web.
 
 Some Office Scripts APIs may not be supported by Excel for Windows, especially on older builds. These include newer APIs and APIs for web-only features. If a script contains unsupported APIs, the script doesn't run and, instead, the **Script Run Status** task pane displays a warning message that says, "This script currently must be run on Excel for the web. Open the workbook in the browser then try again, or contact the script owner for help."  
+
+> [!IMPORTANT]
+> Script buttons require [WebView2](/deployoffice/webview2-install) to work with Excel on Windows. This is installed by default with the latest versions of Excel on Desktop, but if you're unable to click scripts buttons, visit [Download the WebView2 Runtime](https://developer.microsoft.com/en-us/microsoft-edge/webview2/#download-section) and download the browser engine.

--- a/docs/develop/script-buttons.md
+++ b/docs/develop/script-buttons.md
@@ -28,7 +28,7 @@ To stop sharing a script through a button, go to the **More options (…)** menu
 
 These script buttons also work on Windows. Create the button in Excel on the web and users on Windows can run your script with the click of a button. Please note that you cannot edit scripts in Excel on Windows. You can only edit scripts in Excel on the web.
 
-Some Office Scripts APIs may not be supported by Excel for Windows, especially on older builds. These include newer APIs and APIs for web-only features. If a script contains unsupported APIs, the script doesn't run and, instead, the **Script Run Status** task pane displays a warning message that says, "This script currently must be run on Excel for the web. Open the workbook in the browser then try again, or contact the script owner for help."  
+Some Office Scripts APIs may not be supported by Excel on Windows, especially older builds. These include newer APIs and APIs for web-only features. If a script contains unsupported APIs, the script doesn't run and, instead, the **Script Run Status** task pane displays a warning message that says, "This script currently must be run on Excel for the web. Open the workbook in the browser then try again, or contact the script owner for help."  
 
 > [!IMPORTANT]
 > Script buttons require [WebView2](/deployoffice/webview2-install) to work with Excel on Windows. This is installed by default with the latest versions of Excel on Desktop, but if you're unable to click scripts buttons, visit [Download the WebView2 Runtime](https://developer.microsoft.com/en-us/microsoft-edge/webview2/#download-section) and download the browser engine.

--- a/docs/develop/script-buttons.md
+++ b/docs/develop/script-buttons.md
@@ -2,7 +2,7 @@
 title: Run Office Scripts in Excel with buttons
 description: Add buttons to workbooks that control Office Scripts in Excel.
 ms.topic: overview
-ms.date: 04/28/2022
+ms.date: 05/09/2022
 ms.localizationpriority: medium
 ---
 
@@ -27,3 +27,5 @@ To stop sharing a script through a button, go to the **More options (…)** menu
 ## Script buttons on Excel for Windows
 
 These script buttons also work on Windows. Create the button in Excel on the web and users on Windows can run your script with the click of a button. Please note that you cannot edit scripts in Excel on Windows. You can only edit scripts in Excel on the web.
+
+Some Office Scripts APIs may not be supported by Excel for Windows, especially on older builds. These include newer APIs and APIs for web-only features. If a script contains unsupported APIs, the script doesn't run and, instead, the **Script Run Status** task pane displays a warning message that says, "This script currently must be run on Excel for the web. Open the workbook in the browser then try again, or contact the script owner for help."  

--- a/docs/develop/scripting-fundamentals.md
+++ b/docs/develop/scripting-fundamentals.md
@@ -7,7 +7,7 @@ ms.localizationpriority: high
 
 # Scripting fundamentals for Office Scripts in Excel on the web
 
-This article will introduce you to the technical aspects of Office Scripts. You'll learn how the Excel objects work together and how the Code Editor synchronizes with a workbook.
+This article will introduce you to the technical aspects of Office Scripts. You'll learn the critical parts of the TypeScript-based script code and how the Excel objects and APIs work together.
 
 ## TypeScript: The language of Office Scripts
 
@@ -189,7 +189,7 @@ Running this script on the worksheet with the previous table creates the followi
 
 When an Excel object has a collection of one or more objects of the same type, it stores them in an array. For example, a `Workbook` object contains a `Worksheet[]`. This array is accessed by the `Workbook.getWorksheets()` method. `get` methods that are plural, such as `Worksheet.getCharts()`, return the entire object collection as an array. You'll see this pattern throughout the Office Scripts APIs: the `Worksheet` object has a `getTables()` method that returns a `Table[]`, the `Table` object has a `getColumns()` method that returns a `TableColumn[]`, as so on.
 
-The returned array is a normal array, so all the regular array operations are available for your script. You can also access individual objects within the collection using the array index value. For example, `workbook.getTables()[0]` returns the first table in the collection. For more information on using the built-in array functionality with the Office Scripts framework, see [Work with collections](javascript-objects.md#work-with-collections). 
+The returned array is a normal array, so all the regular array operations are available for your script. You can also access individual objects within the collection using the array index value. For example, `workbook.getTables()[0]` returns the first table in the collection. For more information on using the built-in array functionality with the Office Scripts framework, see [Work with collections](javascript-objects.md#work-with-collections).
 
 Individual objects are also accessed from the collection through a `get` method. `get` methods that are singular, such as `Worksheet.getTable(name)`, return a single object and require an ID or name for the specific object. This ID or name is usually set by the script or through the Excel UI.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,14 +2,14 @@
 layout: LandingPage
 ms.topic: landing-page
 title: Office Scripts documentation
-description: Resources for learning Office Scripts in Excel on the web, including tutorials, conceptual articles, and code samples.
+description: Resources for learning Office Scripts in Excel, including tutorials, conceptual articles, and code samples.
 ms.date: 05/24/2021
 ms.localizationpriority: high
 ---
 
 # Office Scripts documentation
 
-Use Office Scripts in Excel on the web to automate your common tasks. Explore the following articles to learn how to create and edit Office Scripts and get started automating today.
+Use Office Scripts in Excel to automate your common tasks. Explore the following articles to learn how to create and edit Office Scripts and get started automating today.
 
 <ul class="panelContent cardsF cols cols3 rows2">
     <li>
@@ -68,7 +68,7 @@ Use Office Scripts in Excel on the web to automate your common tasks. Explore th
 ---
 
 <h2>Other resources</h2>
-<p>Use the following resources to learn about the APIs that Office Scripts use to interact with workbooks in Excel on the web, ask questions about Office Scripts in Excel on the web, or request features for Office Scripts in Excel on the web.</p>
+<p>Use the following resources to learn about the APIs that Office Scripts use, ask questions about Office Scripts, or request features for Office Scripts.</p>
 <ul class="panelContent cardsF cols cols3 rows2">
     <li>
         <div class="cardSize">

--- a/docs/overview/excel.md
+++ b/docs/overview/excel.md
@@ -1,14 +1,14 @@
 ---
-title: Office Scripts in Excel on the web
+title: Office Scripts in Excel
 description: A brief introduction to the Action Recorder and Code Editor for Office Scripts.
 ms.topic: overview
 ms.date: 02/25/2022
 ms.localizationpriority: high
 ---
 
-# Office Scripts in Excel on the web
+# Office Scripts in Excel
 
-Office Scripts in Excel on the web let you automate your day-to-day tasks. You can record your Excel actions with the Action Recorder, which creates a TypeScript language script. You can also create and edit scripts with the Code Editor. Your scripts can then be shared across your organization so your coworkers can also automate their workflows.
+Office Scripts in Excel let you automate your day-to-day tasks. Inside Excel on the web, you can record your actions with the Action Recorder. This creates a TypeScript language script that can be run again any time. You can also create and edit scripts with the Code Editor. Your scripts can then be shared across your organization so your coworkers can also automate their workflows.
 
 This series of documents teaches you how to use these tools. You'll be introduced to the Action Recorder and see how to record your frequent Excel actions. You'll also learn how to make or update your own scripts with the Code Editor.
 
@@ -20,7 +20,7 @@ This series of documents teaches you how to use these tools. You'll be introduce
 
 To use Office Scripts, you'll need the following.
 
-1. [Excel on the web](https://www.office.com/launch/excel) (other platforms, such as desktop, are not supported).
+1. [Excel on the web](https://www.office.com/launch/excel) (Excel for Windows can only use Office Scripts with [script buttons](../develop/script-buttons.md)).
 1. OneDrive for Business.
 1. Any commercial or educational Microsoft 365 license with access to the Microsoft 365 Office desktop apps, such as:
 
@@ -67,7 +67,7 @@ Office Scripts can be shared with other users of an Excel workbook. When you sha
 
 :::image type="content" source="../images/script-sharing.png" alt-text="The script details page showing the 'Share with others in this workbook' option.":::
 
-Add buttons that run scripts to help your colleagues discover your valuable solutions. Learn more about script buttons in [Run Office Scripts with buttons](../develop/script-buttons.md).
+Add buttons that run scripts to help your colleagues discover your valuable solutions and let them run scripts in Excel on Desktop. Learn more about script buttons in [Run Office Scripts with buttons](../develop/script-buttons.md).
 
 :::image type="content" source="../images/add-button.png" alt-text="A button in the worksheet that runs a script when clicked.":::
 
@@ -76,7 +76,7 @@ Add buttons that run scripts to help your colleagues discover your valuable solu
 
 ## Connect Office Scripts to Power Automate
 
-[Power Automate](https://flow.microsoft.com/) is a service that helps you create automated workflows between multiple apps and services. Office Scripts can be used in these workflows, giving you control of your scripts outside of the workbook. You can run your scripts on a schedule, trigger them in response to emails, and much more. Visit the [Run Office Scripts in Excel on the web with Power Automate](../tutorials/excel-power-automate-manual.md) tutorial to learn the basics of connecting these automation services.
+[Power Automate](https://flow.microsoft.com/) is a service that helps you create automated workflows between multiple apps and services. Office Scripts can be used in these workflows, giving you control of your scripts outside of the workbook. You can run your scripts on a schedule, trigger them in response to emails, and much more. Visit the [Run Office Scripts with Power Automate](../tutorials/excel-power-automate-manual.md) tutorial to learn the basics of connecting these automation services.
 
 ## Next steps
 

--- a/docs/resources/add-ins-differences.md
+++ b/docs/resources/add-ins-differences.md
@@ -39,7 +39,7 @@ Office Scripts cannot use [Common APIs](/javascript/api/office). If you need aut
 
 ## See also
 
-- [Office Scripts in Excel on the web](../overview/excel.md)
+- [Office Scripts in Excel](../overview/excel.md)
 - [Differences between Office Scripts and VBA macros](vba-differences.md)
 - [Troubleshooting Office Scripts](../testing/troubleshooting.md)
 - [Build an Excel task pane add-in](/office/dev/add-ins/quickstarts/excel-quickstart-jquery)

--- a/docs/resources/samples/excel-samples.md
+++ b/docs/resources/samples/excel-samples.md
@@ -1,14 +1,15 @@
 ---
-title: Basic scripts for Office Scripts in Excel on the web
-description: A collection of code samples to use with Office Scripts in Excel on the web.
+title: Basic scripts for Office Scripts in Excel
+description: A collection of code samples to use with Office Scripts in Excel.
 ms.date: 03/24/2022
 ms.localizationpriority: medium
 ---
 
-# Basic scripts for Office Scripts in Excel on the web
+# Basic scripts for Office Scripts in Excel
 
-The following samples are simple scripts for you to try on your own workbooks. To use them in Excel on the web:
+The following samples are simple scripts for you to try on your own workbooks. To use them in Excel:
 
+1. Open a workbook in Excel on the web.
 1. Open the **Automate** tab.
 1. Select **New Script**.
 1. Replace the entire script with the sample of your choice.

--- a/docs/resources/vba-differences.md
+++ b/docs/resources/vba-differences.md
@@ -47,7 +47,7 @@ Try the [Call scripts from a manual Power Automate flow](../tutorials/excel-powe
 
 ## See also
 
-- [Office Scripts in Excel on the web](../overview/excel.md)
+- [Office Scripts in Excel](../overview/excel.md)
 - [Run Office Scripts with Power Automate](../develop/power-automate-integration.md)
 - [Differences between Office Scripts and Office Add-ins](add-ins-differences.md)
 - [Troubleshooting Office Scripts](../testing/troubleshooting.md)

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -2,7 +2,7 @@ items:
 - name: Office Scripts documentation
   href: index.md
 
-- name: Office Scripts in Excel on the web
+- name: Office Scripts in Excel
   items:
   - name: Overview
     href: overview/excel.md

--- a/docs/tutorials/excel-read-tutorial.md
+++ b/docs/tutorials/excel-read-tutorial.md
@@ -142,6 +142,6 @@ Now that we know how to read and write to a single cell, let's generalize the sc
 
 ## Next steps
 
-Open the Code Editor and try out some of our [Sample scripts for Office Scripts in Excel on the web](../resources/samples/excel-samples.md). You can also visit [Scripting Fundamentals for Office Scripts in Excel on the web](../develop/scripting-fundamentals.md) to learn more about creating Office Scripts.
+Open the Code Editor and try out some of our [Sample scripts for Office Scripts in Excel](../resources/samples/excel-samples.md). You can also visit [Scripting Fundamentals for Office Scripts in Excel on the web](../develop/scripting-fundamentals.md) to learn more about creating Office Scripts.
 
 The next series of Office Scripts tutorials focus on using Office Scripts with Power Automate. Learn more about the advantages combining the two platforms in [Run Office Scripts with Power Automate](../develop/power-automate-integration.md) or try the [Call scripts from a manual Power Automate flow](excel-power-automate-manual.md) tutorial to create a Power Automate flow that uses an Office Script.

--- a/docs/tutorials/excel-tutorial.md
+++ b/docs/tutorials/excel-tutorial.md
@@ -56,7 +56,7 @@ The previous script colored the "Oranges" row to be orange. Let's add a yellow r
 
     This code gets the current worksheet from the workbook. Then, it sets the fill color of the range **A2:C2**.
 
-    Ranges are a fundamental part of Office Scripts in Excel on the web. A range is a contiguous, rectangular block of cells that contains values, formula, and formatting. They are the basic structure of cells through which you'll perform most of your scripting tasks.
+    Ranges are a fundamental part of Office Scripts in Excel. A range is a contiguous, rectangular block of cells that contains values, formula, and formatting. They are the basic structure of cells through which you'll perform most of your scripting tasks.
 
 3. Add the following line to the end of the script (between where the `color` is set and the closing `}`):
 


### PR DESCRIPTION
The Action Recorder and Code Editor are still only found in Excel on the web. However, scripts can be run on Windows using script buttons. There's also an inherent lack of a platform when talking about Power Automate. So, this PR hopes to rationalize that across the docs without giving a false impression that Excel on the web isn't a fundamental part of the scripting experience.

Additionally, this PR adds content about Windows/web API support. Effectively, APIs in the [online-only](https://docs.microsoft.com/en-us/javascript/api/requirement-sets/excel/excel-api-online-requirement-set?view=excel-js-preview) requirement set cause button-based scripts not to run on Windows. However, the sync API transpilation story makes that complicated to explain.