### PR TITLE
Samples for unhide all rows/cols and freeze selection to excel-sampes

### DIFF
--- a/docs/resources/samples/excel-samples.md
+++ b/docs/resources/samples/excel-samples.md
@@ -208,8 +208,6 @@ function main(workbook: ExcelScript.Workbook) {
 }
 ```
 
-
-
 ## Collections
 
 These samples work with collections of objects in the workbook.

--- a/docs/resources/samples/excel-samples.md
+++ b/docs/resources/samples/excel-samples.md
@@ -164,9 +164,6 @@ function main(workbook: ExcelScript.Workbook) {
       return;
     }
 
-    // Log the address of the used range.
-    console.log(`Used range for the worksheet: ${range.getAddress()}`);
-
     // If no columns are hidden, log message, else, unhide columns
     if (range.getColumnHidden() == false) {
       console.log(`No columns hidden`);

--- a/docs/resources/samples/excel-samples.md
+++ b/docs/resources/samples/excel-samples.md
@@ -192,8 +192,8 @@ function main(workbook: ExcelScript.Workbook) {
     const selectedRange = workbook.getSelectedRange();
 
     // If no cells are selected, end the script. 
-    if (selectedRange == null) {
-      console.log(`No cells in worksheet selected.`);
+    if (!selectedRange) {
+      console.log(`No cells in the worksheet are selected.`);
       return;
     }
 

--- a/docs/resources/samples/excel-samples.md
+++ b/docs/resources/samples/excel-samples.md
@@ -177,7 +177,7 @@ function main(workbook: ExcelScript.Workbook) {
     } else {
       range.setRowHidden(false);
     }
-```
+}
 
 ### Freeze Currently Selected Cells
 

--- a/docs/resources/samples/excel-samples.md
+++ b/docs/resources/samples/excel-samples.md
@@ -181,7 +181,7 @@ function main(workbook: ExcelScript.Workbook) {
 
 ### Freeze Currently Selected Cells
 
-This script checks what cells are currently selected, and freezes that selection so those cells are always visible.
+This script checks what cells are currently selected and freezes that selection, so those cells are always visible.
 
 ```Typescript
 function main(workbook: ExcelScript.Workbook) {

--- a/docs/resources/samples/excel-samples.md
+++ b/docs/resources/samples/excel-samples.md
@@ -146,6 +146,70 @@ function main(workbook: ExcelScript.Workbook) {
 }
 ```
 
+### Unhide All Rows and Columns
+
+This script get the worksheet's used range, checks if there are any hidden rows and columns, and unhides them. 
+
+```Typescript
+function main(workbook: ExcelScript.Workbook) {
+    // Get the currently selected sheet.
+    const selectedSheet = workbook.getActiveWorksheet();
+
+    // Get the entire data range.
+    const range = selectedSheet.getUsedRange();
+
+    // If the used range is empty, end the script.
+    if (!range) {
+      console.log(`No data on this sheet.`)
+      return;
+    }
+
+    // Log the address of the used range.
+    console.log(`Used range for the worksheet: ${range.getAddress()}`);
+
+    // If no columns are hidden, log message, else, unhide columns
+    if (range.getColumnHidden() == false) {
+      console.log(`No columns hidden`);
+    } else {
+      range.setColumnHidden(false);
+    }
+
+    // If no rows are hidden, log message, else, unhide rows.
+    if (range.getRowHidden() == false) {
+      console.log(`No rows hidden`);
+    } else {
+      range.setRowHidden(false);
+    }
+```
+
+### Freeze Currently Selected Cells
+
+This script checks what cells are currently selected, and freezes that selection so those cells are always visible.
+
+```Typescript
+function main(workbook: ExcelScript.Workbook) {
+    // Get the currently selected sheet.
+    const selectedSheet = workbook.getActiveWorksheet();
+
+    // Get the current selected range.
+    const selectedRange = workbook.getSelectedRange();
+
+    // If no cells are selected, end the script. 
+    if (selectedRange == null) {
+      console.log(`No cells in worksheet selected.`);
+      return;
+    }
+
+    // Log the address of the selected range
+    console.log(`Selected range for the worksheet: ${selectedRange.getAddress()}`);
+
+    // Freeze the selected range.
+    selectedSheet.getFreezePanes().freezeAt(selectedRange);
+}
+```
+
+
+
 ## Collections
 
 These samples work with collections of objects in the workbook.


### PR DESCRIPTION
As part of my intern project on Storage & Intelligence, I've created two new samples that will be present in the Samples tab for Office Scripts. Alex Jerabek requested that these samples also be added to the documentation to increase sample code coverage. 