### PR TITLE
Adding Missing ``` to TypeScript block.

### DIFF
--- a/docs/resources/samples/excel-samples.md
+++ b/docs/resources/samples/excel-samples.md
@@ -178,12 +178,13 @@ function main(workbook: ExcelScript.Workbook) {
       range.setRowHidden(false);
     }
 }
+```
 
 ### Freeze Currently Selected Cells
 
 This script checks what cells are currently selected and freezes that selection, so those cells are always visible.
 
-```Typescript
+```TypeScript
 function main(workbook: ExcelScript.Workbook) {
     // Get the currently selected sheet.
     const selectedSheet = workbook.getActiveWorksheet();


### PR DESCRIPTION
Previous PR was missing ticks to close a TypeScript block, resulting in the following section being included as code in the previous section. Added ``` to close first example and corrected Typescript to TypeScript.