### PR TITLE
Fix typos

### DIFF
--- a/docs/resources/samples/external-fetch-calls.md
+++ b/docs/resources/samples/external-fetch-calls.md
@@ -7,9 +7,9 @@ ms.localizationpriority: medium
 
 # Use external fetch calls in Office Scripts
 
-This script gets basic information about a user's GitHub repositories. It shows how to use `fetch` in a simple scenario. For more information about using `fetch` or other external calls, read [External API call support in Office Scripts](../../develop/external-calls.md). For information about working with [JSON]](https://www.w3schools.com/whatis/whatis_json.asp) objects, like what is returned by the GitHub APIs, read [Use JSON to pass data to and from Office Scripts](../../develop/use-json.md).
+This script gets basic information about a user's GitHub repositories. It shows how to use `fetch` in a simple scenario. For more information about using `fetch` or other external calls, read [External API call support in Office Scripts](../../develop/external-calls.md). For information about working with [JSON](https://www.w3schools.com/whatis/whatis_json.asp) objects, like what is returned by the GitHub APIs, read [Use JSON to pass data to and from Office Scripts](../../develop/use-json.md).
 
-Learn more about the GItHub APIs being used in the [GitHub API reference](https://docs.github.com/rest/reference/repos#list-repositories-for-a-user). You can also see the raw API call output by visiting `https://api.github.com/users/{USERNAME}/repos` in a web browser (be sure to replace the {USERNAME} placeholder with your GitHub ID).
+Learn more about the GitHub APIs being used in the [GitHub API reference](https://docs.github.com/rest/reference/repos#list-repositories-for-a-user). You can also see the raw API call output by visiting `https://api.github.com/users/{USERNAME}/repos` in a web browser (be sure to replace the {USERNAME} placeholder with your GitHub ID).
 
 ![Get repositories info example](../../images/git.png)
 


### PR DESCRIPTION
This PR fixes a couple of typos on the "Use external fetch calls in Office Scripts" page.