### PR TITLE
[excel] (Action Recorder) Updating support note to clarify Action Recorder is web-only

### DIFF
--- a/docs/includes/platform-requirements.md
+++ b/docs/includes/platform-requirements.md
@@ -1,6 +1,7 @@
 To use Office Scripts, you'll need the following.
 
 1. Excel for Windows, for Mac, or on the web.
+    1. The [Action Recorder](../overview/excel.md#action-recorder-web-only) is only available in Excel on the web.
 1. OneDrive for Business.
 1. Any commercial or educational Microsoft 365 license with access to the Microsoft 365 Office desktop apps, such as:
 

--- a/docs/overview/excel.md
+++ b/docs/overview/excel.md
@@ -2,7 +2,7 @@
 title: Office Scripts in Excel
 description: A brief introduction to the Action Recorder and Code Editor for Office Scripts.
 ms.topic: overview
-ms.date: 01/09/2023
+ms.date: 03/10/2023
 ms.localizationpriority: high
 ---
 

--- a/docs/testing/platform-limits.md
+++ b/docs/testing/platform-limits.md
@@ -1,7 +1,7 @@
 ---
 title: Platform limits and requirements with Office Scripts
 description: Resource limits and browser support for Office Scripts when used with Excel.
-ms.date: 02/24/2023
+ms.date: 03/10/2023
 ms.localizationpriority: medium
 ---
 


### PR DESCRIPTION
This PR is in response to #585. It highlights that the Action Recorder is a web-only feature in the two places we talk about platform support.