### PR TITLE
[excel] (Power Automate) Clarify script storage limitations in PA integration article

### DIFF
--- a/docs/develop/power-automate-integration.md
+++ b/docs/develop/power-automate-integration.md
@@ -2,7 +2,7 @@
 title: Run Office Scripts with Power Automate
 description: How to get Office Scripts for Excel working with a Power Automate workflow.
 ms.topic: integration
-ms.date: 06/15/2023
+ms.date: 08/10/2023
 ms.localizationpriority: medium
 ---
 
@@ -39,11 +39,11 @@ This opens a task pane with several options to begin connecting your Office Scri
 
 [Connectors](/connectors/connectors) are the bridges between Power Automate and applications. The [Excel Online (Business) connector](/connectors/excelonlinebusiness) gives your flows access to Excel workbooks. The "Run script" action lets you call any Office Script accessible through the selected workbook. You can also give your scripts input parameters so data can be provided by the flow, or have your script return information for later steps in the flow.
 
+> [!NOTE]
+> The **Run script** Power Automate action only supports scripts stored in your OneDrive. To run scripts shared in SharePoint libraries, use the **Run script from SharePoint library (Preview)** action. This action is currently in preview and is subject to change based on feedback. If you encounter any issues with this action, please report them through the **Help** > **Give Feedback** option in Power Automate.
+
 > [!IMPORTANT]
 > The "Run script" action gives people who use the Excel connector significant access to your workbook and its data. Additionally, there are security risks with scripts that make external API calls, as explained in [External calls from Power Automate](external-calls.md). If your admin is concerned with the exposure of highly sensitive data, they can either turn off the Excel Online connector or restrict access to Office Scripts through the [Office Scripts administrator controls](/microsoft-365/admin/manage/manage-office-scripts-settings).
-
-> [!NOTE]
-> Power Automate supports running scripts stored on SharePoint with the **Run script from SharePoint library (Preview)** action. This action is currently in preview and is subject to change based on feedback. If you encounter any issues with this action, please report them through the **Help** > **Give Feedback** option in Power Automate.
 
 ## Data transfer in flows for scripts
 


### PR DESCRIPTION
Fixes #623.

This PR aims to make the OneDrive script location limitation in Power Automate clearer.