### PR TITLE
Refine product feedback link

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -42,7 +42,7 @@
       "extendBreadcrumb": true,
       "feedback_system": "GitHub",
       "feedback_github_repo": "OfficeDev/office-scripts-docs",
-      "feedback_product_url": "/answers/topics/312419/office-scripts-excel-dev.html",
+      "feedback_product_url": "/answers/tags/321/office-development",
       "ms.suite": "office",
       "ms.author": "o365devx",
       "author": "o365devx",


### PR DESCRIPTION
The original link is redirecting to the new one. Do suggest a more appropriate URL if you have one.