### PR TITLE
[excel] (Tutorials) Convert tutorial titles to reflect scenarios instead of features

### DIFF
--- a/docs/develop/best-practices.md
+++ b/docs/develop/best-practices.md
@@ -109,7 +109,7 @@ A [`throw`](https://developer.mozilla.org/docs/web/javascript/reference/statemen
 
 However, if your script is running as part of a Power Automate flow, you may want to stop the flow from continuing. A `throw` statement stops the script and tells the flow to stop as well.
 
-The following script shows how to use the `throw` statement in the table checking example.
+The following script shows how to use the `throw` statement in the table-checking example.
 
 ```TypeScript
 function main(workbook: ExcelScript.Workbook) {

--- a/docs/develop/best-practices.md
+++ b/docs/develop/best-practices.md
@@ -109,7 +109,7 @@ A [`throw`](https://developer.mozilla.org/docs/web/javascript/reference/statemen
 
 However, if your script is running as part of a Power Automate flow, you may want to stop the flow from continuing. A `throw` statement stops the script and tells the flow to stop as well.
 
-The following script shows how to use the `throw` statement in our table checking example.
+The following script shows how to use the `throw` statement in the table checking example.
 
 ```TypeScript
 function main(workbook: ExcelScript.Workbook) {

--- a/docs/develop/pivottables.md
+++ b/docs/develop/pivottables.md
@@ -117,7 +117,7 @@ There are three ways to filter a PivotTable.
 
 ### FilterPivotHierarchies
 
-`FilterPivotHierarchies` add an additional hierarchy to filter every data row. Any row with an item that is filtered out is excluded from the PivotTable and its summaries. Since these filters are based on items, they only work on discrete values. If "Classification" is a filter hierarchy in our sample, users can select the values of "Organic" and "Conventional" for the filter. Similarly, if "Crates Sold Wholesale" is selected, the filter options would be the individual numbers, such as 120 and 150, instead of numerical ranges.
+`FilterPivotHierarchies` add an additional hierarchy to filter every data row. Any row with an item that is filtered out is excluded from the PivotTable and its summaries. Since these filters are based on items, they only work on discrete values. If "Classification" is a filter hierarchy in the sample, users can select the values of "Organic" and "Conventional" for the filter. Similarly, if "Crates Sold Wholesale" is selected, the filter options would be the individual numbers, such as 120 and 150, instead of numerical ranges.
 
 `FilterPivotHierarchies` are created with all values selected. This means that nothing is filtered until the user manually interacts with the filter control or a `PivotManualFilter` is set on the field belonging to the `FilterPivotHierarchy`.
 

--- a/docs/develop/power-automate-integration.md
+++ b/docs/develop/power-automate-integration.md
@@ -68,7 +68,7 @@ Power Automate lets you pass pieces of data between flow actions. Scripts can be
 
 Learn the details of how to pass data to and from your scripts with the following documentation.
 
-- Learn by doing with the [Tutorial: Automatically save content from emails in a workbook](../tutorials/excel-power-automate-trigger.md) and [Tutorial: Send weekly email reminders based on spreadsheet data](../tutorials/excel-power-automate-returns.md) tutorials.
+- Learn by doing with [Tutorial: Automatically save content from emails in a workbook](../tutorials/excel-power-automate-trigger.md) and [Tutorial: Send weekly email reminders based on spreadsheet data](../tutorials/excel-power-automate-returns.md).
 - Try the [Automated task reminders](../resources/scenarios/task-reminders.md) sample scenario to see everything in action.
 - Read [Pass data to and from scripts in Power Automate](power-automate-parameters-returns.md) for more usage scenarios and the technical TypeScript details.
 

--- a/docs/develop/power-automate-integration.md
+++ b/docs/develop/power-automate-integration.md
@@ -18,9 +18,9 @@ If you are new to Power Automate, we recommend visiting [Get started with Power 
 
 There are three step-by-step tutorials for Power Automate and Office Scripts. These show how to combine the automate services and pass data between a workbook and a flow.
 
-- [Call scripts from a manual Power Automate flow](../tutorials/excel-power-automate-manual.md)
-- [Pass data to scripts in an automatically-run Power Automate flow](../tutorials/excel-power-automate-trigger.md)
-- [Return data from a script to an automatically-run Power Automate flow](../tutorials//excel-power-automate-returns.md)
+- [Tutorial: Update a spreadsheet from a Power Automate flow](../tutorials/excel-power-automate-manual.md)
+- [Tutorial: Automatically save content from emails in a workbook](../tutorials/excel-power-automate-trigger.md)
+- [Tutorial: Send email reminders every week based on spreadsheet data](../tutorials//excel-power-automate-returns.md)
 
 ### Create a flow from Excel
 
@@ -68,7 +68,7 @@ Power Automate lets you pass pieces of data between flow actions. Scripts can be
 
 Learn the details of how to pass data to and from your scripts with the following documentation.
 
-- Learn by doing with the [Pass data to scripts in an automatically-run Power Automate flow](../tutorials/excel-power-automate-trigger.md) and [Return data from a script to an automatically-run Power Automate flow](../tutorials/excel-power-automate-returns.md) tutorials.
+- Learn by doing with the [Tutorial: Automatically save content from emails in a workbook](../tutorials/excel-power-automate-trigger.md) and [Tutorial: Send email reminders every week based on spreadsheet data](../tutorials/excel-power-automate-returns.md) tutorials.
 - Try the [Automated task reminders](../resources/scenarios/task-reminders.md) sample scenario to see everything in action.
 - Read [Pass data to and from scripts in Power Automate](power-automate-parameters-returns.md) for more usage scenarios and the technical TypeScript details.
 
@@ -101,7 +101,7 @@ function main(
 
 ## See also
 
-- [Call scripts from a manual Power Automate flow](../tutorials/excel-power-automate-manual.md)
+- [Tutorial: Update a spreadsheet from a Power Automate flow](../tutorials/excel-power-automate-manual.md)
 - [Pass data to and from scripts in Power Automate](power-automate-parameters-returns.md)
 - [Troubleshooting information for Power Automate with Office Scripts](../testing/power-automate-troubleshooting.md)
 - [Get started with Power Automate](/power-automate/getting-started)

--- a/docs/develop/power-automate-integration.md
+++ b/docs/develop/power-automate-integration.md
@@ -20,7 +20,7 @@ There are three step-by-step tutorials for Power Automate and Office Scripts. Th
 
 - [Tutorial: Update a spreadsheet from a Power Automate flow](../tutorials/excel-power-automate-manual.md)
 - [Tutorial: Automatically save content from emails in a workbook](../tutorials/excel-power-automate-trigger.md)
-- [Tutorial: Send email reminders every week based on spreadsheet data](../tutorials//excel-power-automate-returns.md)
+- [Tutorial: Send weekly email reminders based on spreadsheet data](../tutorials//excel-power-automate-returns.md)
 
 ### Create a flow from Excel
 
@@ -68,7 +68,7 @@ Power Automate lets you pass pieces of data between flow actions. Scripts can be
 
 Learn the details of how to pass data to and from your scripts with the following documentation.
 
-- Learn by doing with the [Tutorial: Automatically save content from emails in a workbook](../tutorials/excel-power-automate-trigger.md) and [Tutorial: Send email reminders every week based on spreadsheet data](../tutorials/excel-power-automate-returns.md) tutorials.
+- Learn by doing with the [Tutorial: Automatically save content from emails in a workbook](../tutorials/excel-power-automate-trigger.md) and [Tutorial: Send weekly email reminders based on spreadsheet data](../tutorials/excel-power-automate-returns.md) tutorials.
 - Try the [Automated task reminders](../resources/scenarios/task-reminders.md) sample scenario to see everything in action.
 - Read [Pass data to and from scripts in Power Automate](power-automate-parameters-returns.md) for more usage scenarios and the technical TypeScript details.
 

--- a/docs/develop/power-automate-parameters-returns.md
+++ b/docs/develop/power-automate-parameters-returns.md
@@ -38,7 +38,7 @@ Acceptable types for returning data are the same as for parameters. Details on t
 
 ## See also
 
-- [Call scripts from a manual Power Automate flow](../tutorials/excel-power-automate-manual.md)
+- [Tutorial: Update a spreadsheet from a Power Automate flow](../tutorials/excel-power-automate-manual.md)
 - [Get user input for scripts](user-input.md)
 - [Run Office Scripts with Power Automate](power-automate-integration.md)
 - [Troubleshooting information for Power Automate with Office Scripts](../testing/power-automate-troubleshooting.md)

--- a/docs/develop/scripting-fundamentals.md
+++ b/docs/develop/scripting-fundamentals.md
@@ -10,7 +10,7 @@ ms.localizationpriority: high
 
 This article will introduce you to the technical aspects of Office Scripts. You'll learn the critical parts of the TypeScript-based script code and how the Excel objects and APIs work together.
 
-If you would prefer to get started with an interactive experience, try the tutorial [Tutorial: Create and format an Excel table](../tutorials/excel-tutorial.md) or visit our [samples](../resources/samples/samples-overview.md).
+If you would prefer to get started with an interactive experience, try [Tutorial: Create and format an Excel table](../tutorials/excel-tutorial.md) or visit our [samples](../resources/samples/samples-overview.md).
 
 ## TypeScript: The language of Office Scripts
 

--- a/docs/develop/scripting-fundamentals.md
+++ b/docs/develop/scripting-fundamentals.md
@@ -10,7 +10,7 @@ ms.localizationpriority: high
 
 This article will introduce you to the technical aspects of Office Scripts. You'll learn the critical parts of the TypeScript-based script code and how the Excel objects and APIs work together.
 
-If you would prefer to get started with an interactive experience, try the tutorial [Record, edit, and create Office Scripts in Excel](../tutorials/excel-tutorial.md) or visit our [samples](../resources/samples/samples-overview.md).
+If you would prefer to get started with an interactive experience, try the tutorial [Tutorial: Create and format an Excel table](../tutorials/excel-tutorial.md) or visit our [samples](../resources/samples/samples-overview.md).
 
 ## TypeScript: The language of Office Scripts
 
@@ -323,8 +323,8 @@ For information specific to the PivotTable object model, see [Work with PivotTab
 
 ## See also
 
-- [Record, edit, and create Office Scripts in Excel](../tutorials/excel-tutorial.md)
-- [Read workbook data with Office Scripts in Excel](../tutorials/excel-read-tutorial.md)
+- [Tutorial: Create and format an Excel table](../tutorials/excel-tutorial.md)
+- [Tutorial: Clean and normalize Excel workbook data](../tutorials/excel-read-tutorial.md)
 - [Office Scripts API reference](/javascript/api/office-scripts/overview)
 - [Work with PivotTables in Office Scripts](pivottables.md)
 - [Using built-in JavaScript objects in Office Scripts](javascript-objects.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@ Use Office Scripts in Excel to automate your common tasks. Explore the following
                     </div>
                     <div class="cardText">
                         <h3>Getting started</h3>
-                        <p><a href="tutorials/excel-tutorial.md">Complete the tutorial to learn how to record, edit, and create Office Scripts in Excel.</a></p>
+                        <p><a href="tutorials/excel-tutorial.md">Create and format a table with Office Scripts.</a></p>
                     </div>
                 </div>
             </div>

--- a/docs/resources/samples/count-blank-rows.md
+++ b/docs/resources/samples/count-blank-rows.md
@@ -13,7 +13,7 @@ This project includes two scripts:
 * [Count blank rows on all sheets](#sample-code-count-blank-rows-on-all-sheets): Traverses the used range on _all of the worksheets_ and returns a blank row count.
 
 > [!NOTE]
-> For our script, a blank row is any row where there's no data. The row can have formatting.
+> For your script, a blank row is any row where there's no data. The row can have formatting.
 
 _This sheet returns count of 4 blank rows_
 

--- a/docs/resources/samples/range-samples.md
+++ b/docs/resources/samples/range-samples.md
@@ -317,4 +317,4 @@ We welcome suggestions for new samples. If there's a common scenario that would 
 
 * [Sudhi Ramamurthy's "Range basics" on YouTube](https://youtu.be/4emjkOFdLBA)
 * [Office Scripts samples and scenarios](samples-overview.md)
-* [Record, edit, and create Office Scripts in Excel](../../tutorials/excel-tutorial.md)
+* [Tutorial: Create and format an Excel table](../../tutorials/excel-tutorial.md)

--- a/docs/resources/vba-differences.md
+++ b/docs/resources/vba-differences.md
@@ -42,7 +42,7 @@ Office Scripts don't support Excel-level [events](/office/vba/excel/concepts/eve
 
 VBA doesn't have a Power Automate connector. All supported VBA scenarios involve a user attending to the macro's execution.
 
-Office Scripts can be run through Power Automate. Your workbook can be updated through scheduled or event-driven flows, letting you automate workflows without even opening Excel. Try the [Call scripts from a manual Power Automate flow](../tutorials/excel-power-automate-manual.md) tutorial to start learning about Power Automate. You can also check out the [Automated task reminders](scenarios/task-reminders.md) sample to see Office Scripts connected to Teams through Power Automate in a real-world scenario.
+Office Scripts can be run through Power Automate. Your workbook can be updated through scheduled or event-driven flows, letting you automate workflows without even opening Excel. Try the [Tutorial: Update a spreadsheet from a Power Automate flow](../tutorials/excel-power-automate-manual.md) tutorial to start learning about Power Automate. You can also check out the [Automated task reminders](scenarios/task-reminders.md) sample to see Office Scripts connected to Teams through Power Automate in a real-world scenario.
 
 ## See also
 

--- a/docs/resources/vba-differences.md
+++ b/docs/resources/vba-differences.md
@@ -42,7 +42,7 @@ Office Scripts don't support Excel-level [events](/office/vba/excel/concepts/eve
 
 VBA doesn't have a Power Automate connector. All supported VBA scenarios involve a user attending to the macro's execution.
 
-Office Scripts can be run through Power Automate. Your workbook can be updated through scheduled or event-driven flows, letting you automate workflows without even opening Excel. Try the [Tutorial: Update a spreadsheet from a Power Automate flow](../tutorials/excel-power-automate-manual.md) tutorial to start learning about Power Automate. You can also check out the [Automated task reminders](scenarios/task-reminders.md) sample to see Office Scripts connected to Teams through Power Automate in a real-world scenario.
+Office Scripts can be run through Power Automate. Your workbook can be updated through scheduled or event-driven flows, letting you automate workflows without even opening Excel. Try [Tutorial: Update a spreadsheet from a Power Automate flow](../tutorials/excel-power-automate-manual.md) to start learning about Power Automate. You can also check out the [Automated task reminders](scenarios/task-reminders.md) sample to see Office Scripts connected to Teams through Power Automate in a real-world scenario.
 
 ## See also
 

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -8,15 +8,15 @@ items:
     href: overview/excel.md
   - name: Tutorials
     items:
-    - name: Learn the basics of Office Scripts
+    - name: Create and format an Excel table
       href: tutorials/excel-tutorial.md
-    - name: Read workbook data with a script
+    - name: Clean and normalize Excel workbook data
       href: tutorials/excel-read-tutorial.md
-    - name: Call scripts from a manual Power Automate flow
+    - name: Update a spreadsheet from a Power Automate flow
       href: tutorials/excel-power-automate-manual.md
-    - name: Use data in a script from an automatically-run Power Automate flow
+    - name: Automatically save content from emails in a workbook
       href: tutorials/excel-power-automate-trigger.md
-    - name: Pass data from a script to Power Automate flow
+    - name: Send email reminders every week based on spreadsheet data
       href: tutorials/excel-power-automate-returns.md
   - name: Script fundamentals
     href: develop/scripting-fundamentals.md
@@ -70,6 +70,8 @@ items:
         href: resources/samples/range-samples.md
       - name: Tables
         href: resources/samples/table-samples.md
+      - name: Dates
+        href: resources/samples/javascript-dates.md
       - name: Add comments
         href: resources/samples/add-excel-comments.md
       - name: Add images to a workbook
@@ -80,8 +82,6 @@ items:
         href: resources/samples/data-validation-samples.md
       - name: Create a workbook table of contents
         href: resources/samples/table-of-contents.md
-      - name: JavaScript Dates
-        href: resources/samples/javascript-dates.md
       - name: Remove table column filters
         href: resources/samples/clear-table-filter-for-active-cell.md
       - name: Report day-to-day changes in Power Automate

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -16,7 +16,7 @@ items:
       href: tutorials/excel-power-automate-manual.md
     - name: Automatically save content from emails in a workbook
       href: tutorials/excel-power-automate-trigger.md
-    - name: Send email reminders every week based on spreadsheet data
+    - name: Send weekly email reminders based on spreadsheet data
       href: tutorials/excel-power-automate-returns.md
   - name: Script fundamentals
     href: develop/scripting-fundamentals.md

--- a/docs/tutorials/excel-power-automate-manual.md
+++ b/docs/tutorials/excel-power-automate-manual.md
@@ -10,7 +10,7 @@ ms.localizationpriority: high
 This tutorial teaches you how to run an Office Script for Excel through [Power Automate](https://make.powerautomate.com). You'll make a script that updates the values of two cells with the current time. You'll then connect that script to a manually triggered Power Automate flow, so that the script is run whenever a button in Power Automate is selected. Once you understand the basic pattern, you can expand the flow to include other applications and automate more of your daily workflow.
 
 > [!TIP]
-> If you are new to Office Scripts, we recommend starting with the [Tutorial: Create and format an Excel table](excel-tutorial.md) tutorial. [Office Scripts use TypeScript](../overview/code-editor-environment.md) and this tutorial is intended for people with beginner to intermediate-level knowledge of JavaScript or TypeScript. If you're new to JavaScript, we recommend starting with the [Mozilla JavaScript tutorial](https://developer.mozilla.org/docs/Web/JavaScript/Guide/Introduction).
+> If you are new to Office Scripts, we recommend starting with [Tutorial: Create and format an Excel table](excel-tutorial.md). [Office Scripts use TypeScript](../overview/code-editor-environment.md) and this tutorial is intended for people with beginner to intermediate-level knowledge of JavaScript or TypeScript. If you're new to JavaScript, we recommend starting with the [Mozilla JavaScript tutorial](https://developer.mozilla.org/docs/Web/JavaScript/Guide/Introduction).
 
 ## Prerequisites
 
@@ -125,4 +125,4 @@ Your flow is now ready to be run through Power Automate. You can test it using t
 
 ## Next steps
 
-Complete the [Tutorial: Automatically save content from emails in a workbook](excel-power-automate-trigger.md) tutorial. It teaches you how to pass data from a workflow service to your Office Script and run the Power Automate flow when certain events occur.
+Complete [Tutorial: Automatically save content from emails in a workbook](excel-power-automate-trigger.md). It teaches you how to pass data from a workflow service to your Office Script and run the Power Automate flow when certain events occur.

--- a/docs/tutorials/excel-power-automate-manual.md
+++ b/docs/tutorials/excel-power-automate-manual.md
@@ -1,16 +1,16 @@
 ---
-title: Call scripts from a manual Power Automate flow
+title: 'Tutorial: Update a spreadsheet from a Power Automate flow'
 description: A tutorial about how to use an Office Script in Power Automate through a manual trigger.
-ms.date: 11/10/2023
+ms.date: 11/14/2023
 ms.localizationpriority: high
 ---
 
-# Call scripts from a manual Power Automate flow
+# Tutorial: Update a spreadsheet from a Power Automate flow
 
 This tutorial teaches you how to run an Office Script for Excel through [Power Automate](https://make.powerautomate.com). You'll make a script that updates the values of two cells with the current time. You'll then connect that script to a manually triggered Power Automate flow, so that the script is run whenever a button in Power Automate is selected. Once you understand the basic pattern, you can expand the flow to include other applications and automate more of your daily workflow.
 
 > [!TIP]
-> If you are new to Office Scripts, we recommend starting with the [Record, edit, and create Office Scripts in Excel](excel-tutorial.md) tutorial. [Office Scripts use TypeScript](../overview/code-editor-environment.md) and this tutorial is intended for people with beginner to intermediate-level knowledge of JavaScript or TypeScript. If you're new to JavaScript, we recommend starting with the [Mozilla JavaScript tutorial](https://developer.mozilla.org/docs/Web/JavaScript/Guide/Introduction).
+> If you are new to Office Scripts, we recommend starting with the [Tutorial: Create and format an Excel table](excel-tutorial.md) tutorial. [Office Scripts use TypeScript](../overview/code-editor-environment.md) and this tutorial is intended for people with beginner to intermediate-level knowledge of JavaScript or TypeScript. If you're new to JavaScript, we recommend starting with the [Mozilla JavaScript tutorial](https://developer.mozilla.org/docs/Web/JavaScript/Guide/Introduction).
 
 ## Prerequisites
 
@@ -125,4 +125,4 @@ Your flow is now ready to be run through Power Automate. You can test it using t
 
 ## Next steps
 
-Complete the [Pass data to scripts in an automatically-run Power Automate flow](excel-power-automate-trigger.md) tutorial. It teaches you how to pass data from a workflow service to your Office Script and run the Power Automate flow when certain events occur.
+Complete the [Tutorial: Automatically save content from emails in a workbook](excel-power-automate-trigger.md) tutorial. It teaches you how to pass data from a workflow service to your Office Script and run the Power Automate flow when certain events occur.

--- a/docs/tutorials/excel-power-automate-returns.md
+++ b/docs/tutorials/excel-power-automate-returns.md
@@ -10,9 +10,9 @@ ms.localizationpriority: high
 This tutorial teaches you how to return information from an Office Script for Excel as part of an automated [Power Automate](https://make.powerautomate.com) workflow. You'll make a script that looks through a schedule and works with a flow to send reminder emails. This flow will run on a regular schedule, providing these reminders on your behalf.
 
 > [!TIP]
-> If you're new to Office Scripts, we recommend starting with the [Tutorial: Create and format an Excel table](excel-tutorial.md) tutorial.
+> If you're new to Office Scripts, we recommend starting with [Tutorial: Create and format an Excel table](excel-tutorial.md).
 >
-> If you're new to Power Automate, we recommend starting with the [Tutorial: Update a spreadsheet from a Power Automate flow](excel-power-automate-manual.md) and [Tutorial: Automatically save content from emails in a workbook](excel-power-automate-trigger.md) tutorials.
+> If you're new to Power Automate, we recommend starting with [Tutorial: Update a spreadsheet from a Power Automate flow](excel-power-automate-manual.md) and [Tutorial: Automatically save content from emails in a workbook](excel-power-automate-trigger.md).
 >
 > [Office Scripts use TypeScript](../overview/code-editor-environment.md) and this tutorial is intended for people with beginner to intermediate-level knowledge of JavaScript or TypeScript. If you're new to JavaScript, we recommend starting with the [Mozilla JavaScript tutorial](https://developer.mozilla.org/docs/Web/JavaScript/Guide/Introduction).
 

--- a/docs/tutorials/excel-power-automate-returns.md
+++ b/docs/tutorials/excel-power-automate-returns.md
@@ -1,18 +1,18 @@
 ---
-title: Return data from a script to an automatically-run Power Automate flow
+title: 'Tutorial: Send email reminders every week based on spreadsheet data'
 description: A tutorial that shows how to send reminder emails by running Office Scripts for Excel through Power Automate.
-ms.date: 10/01/2022
+ms.date: 11/14/2023
 ms.localizationpriority: high
 ---
 
-# Return data from a script to an automatically-run Power Automate flow
+# Tutorial: Send email reminders every week based on spreadsheet data
 
 This tutorial teaches you how to return information from an Office Script for Excel as part of an automated [Power Automate](https://make.powerautomate.com) workflow. You'll make a script that looks through a schedule and works with a flow to send reminder emails. This flow will run on a regular schedule, providing these reminders on your behalf.
 
 > [!TIP]
-> If you're new to Office Scripts, we recommend starting with the [Record, edit, and create Office Scripts in Excel](excel-tutorial.md) tutorial.
+> If you're new to Office Scripts, we recommend starting with the [Tutorial: Create and format an Excel table](excel-tutorial.md) tutorial.
 >
-> If you're new to Power Automate, we recommend starting with the [Call scripts from a manual Power Automate flow](excel-power-automate-manual.md) and [Pass data to scripts in an automatically-run Power Automate flow](excel-power-automate-trigger.md) tutorials.
+> If you're new to Power Automate, we recommend starting with the [Tutorial: Update a spreadsheet from a Power Automate flow](excel-power-automate-manual.md) and [Tutorial: Automatically save content from emails in a workbook](excel-power-automate-trigger.md) tutorials.
 >
 > [Office Scripts use TypeScript](../overview/code-editor-environment.md) and this tutorial is intended for people with beginner to intermediate-level knowledge of JavaScript or TypeScript. If you're new to JavaScript, we recommend starting with the [Mozilla JavaScript tutorial](https://developer.mozilla.org/docs/Web/JavaScript/Guide/Introduction).
 
@@ -41,14 +41,14 @@ This tutorial teaches you how to return information from an Office Script for Ex
 
 1. Name the script **Get On-Call Person**.
 
-1. You should now have an empty script. We want to use the script to get an email address from the spreadsheet. Change `main` to return a string, like this:
+1. You should now have an empty script. You want a script that gets an email address from the spreadsheet. Change `main` to return a string, like this:
 
     ```TypeScript
     function main(workbook: ExcelScript.Workbook) : string {
     }
     ```
 
-1. Next, you need to get all the data from the table. That lets us look through each row with the script. Add the following code inside the `main` function.
+1. Next, you need to get all the data from the table. That lets the script look at each row. Add the following code inside the `main` function.
 
     ```TypeScript
     // Get the H1 worksheet.
@@ -61,7 +61,7 @@ This tutorial teaches you how to return information from an Office Script for Ex
     let tableValues = table.getRangeBetweenHeaderAndTotal().getValues();
     ```
 
-1. The dates in the table are stored using [Excel's date serial number](https://support.microsoft.com/office/e7fe7167-48a9-4b96-bb53-5612a800b487). We need to convert those dates to JavaScript dates in order to compare them. We'll add a helper function to our script. Add the following code outside of the `main` function.
+1. The dates in the table are stored using [Excel's date serial number](https://support.microsoft.com/office/e7fe7167-48a9-4b96-bb53-5612a800b487). You need to convert those dates to JavaScript dates in order to compare them. Add the following helper function outside of the `main` function.
 
     ```TypeScript
     // Convert the Excel date to a JavaScript Date object.
@@ -71,7 +71,7 @@ This tutorial teaches you how to return information from an Office Script for Ex
     }
     ```
 
-1. Now, you need to figure out which person is on call right now. Their row will have a start and end date surrounding the current date. We'll write the script to assume only one person is on call at a time. Scripts can return arrays to handle multiple values, but you can return the first matching email address for this tutorial. Add the following code to the end of the `main` function.
+1. Now, you need to figure out which person is on call right now. Their row will have a start and end date surrounding the current date. The script will assume only one person is on call at a time. Scripts can return arrays to handle multiple values, but you can return the first matching email address for this tutorial. Add the following code to the end of the `main` function.
 
     ```TypeScript
     // Look for the first row where today's date is between the row's start and end dates.
@@ -130,7 +130,7 @@ This tutorial teaches you how to return information from an Office Script for Ex
 
     :::image type="content" source="../images/power-automate-return-tutorial-2.png" alt-text="The Scheduled cloud flow button in Power Automate.":::
 
-1. Next, set the schedule for this flow. Our spreadsheet has a new on-call assignment starting every Monday in the first half of 2022. Let's set the flow to run first thing Monday mornings. Use the following options to configure the flow to run on Monday each week.
+1. Next, set the schedule for this flow. Your spreadsheet has a new on-call assignment starting every Monday in the first half of 2022. Set the flow to run first thing Monday mornings. Use the following options to configure the flow to run on Monday each week.
 
     - **Flow name**: Notify On-Call Person
     - **Starting**: 1/3/22 at 1:00am
@@ -162,7 +162,7 @@ This tutorial teaches you how to return information from an Office Script for Ex
 
 1. Select **New step**.
 
-1. We'll end the flow by sending the reminder email. Select **Send an email (V2)** by using the connector's search bar. Use the **Add dynamic content** control to add the email address returned by the script. This will be labelled **result** with the Excel icon next to it. You can provide whatever subject and body text you'd like.
+1. End the flow by sending the reminder email. Select **Send an email (V2)** by using the connector's search bar. Use the **Add dynamic content** control to add the email address returned by the script. This will be labelled **result** with the Excel icon next to it. You can provide whatever subject and body text you'd like.
 
     :::image type="content" source="../images/power-automate-return-tutorial-5.png" alt-text="The Power Automate Outlook connector settings for sending an email. The options include the file to send, the subject of the email, and the body of the email as well as advanced options.":::
 

--- a/docs/tutorials/excel-power-automate-returns.md
+++ b/docs/tutorials/excel-power-automate-returns.md
@@ -1,11 +1,11 @@
 ---
-title: 'Tutorial: Send email reminders every week based on spreadsheet data'
+title: 'Tutorial: Send weekly email reminders based on spreadsheet data'
 description: A tutorial that shows how to send reminder emails by running Office Scripts for Excel through Power Automate.
 ms.date: 11/14/2023
 ms.localizationpriority: high
 ---
 
-# Tutorial: Send email reminders every week based on spreadsheet data
+# Tutorial: Send weekly email reminders based on spreadsheet data
 
 This tutorial teaches you how to return information from an Office Script for Excel as part of an automated [Power Automate](https://make.powerautomate.com) workflow. You'll make a script that looks through a schedule and works with a flow to send reminder emails. This flow will run on a regular schedule, providing these reminders on your behalf.
 

--- a/docs/tutorials/excel-power-automate-trigger.md
+++ b/docs/tutorials/excel-power-automate-trigger.md
@@ -1,16 +1,16 @@
 ---
-title: Pass data to scripts in an automatically-run Power Automate flow
+title: 'Tutorial: Automatically save content from emails in a workbook'
 description: A tutorial about running Office Scripts for Excel through Power Automate when mail is received and passing flow data to the script.
-ms.date: 10/01/2022
+ms.date: 11/14/2023
 ms.localizationpriority: high
 ---
 
-# Pass data to scripts in an automatically-run Power Automate flow
+# Tutorial: Automatically save content from emails in a workbook
 
 This tutorial teaches you how to use an Office Script for Excel with an automated [Power Automate](https://make.powerautomate.com) workflow. Your script will automatically run each time you receive an email, recording information from the email in an Excel workbook. Being able to pass data from other applications into an Office Script gives you a great deal of flexibility and freedom in your automated processes.
 
 > [!TIP]
-> If you're new to Office Scripts, we recommend starting with the [Record, edit, and create Office Scripts in Excel](excel-tutorial.md) tutorial. If you're new to Power Automate, we recommend starting with the [Call scripts from a manual Power Automate flow](excel-power-automate-manual.md) tutorial. [Office Scripts use TypeScript](../overview/code-editor-environment.md) and this tutorial is intended for people with beginner to intermediate-level knowledge of JavaScript or TypeScript. If you're new to JavaScript, we recommend starting with the [Mozilla JavaScript tutorial](https://developer.mozilla.org/docs/Web/JavaScript/Guide/Introduction).
+> If you're new to Office Scripts, we recommend starting with the [Tutorial: Create and format an Excel table](excel-tutorial.md) tutorial. If you're new to Power Automate, we recommend starting with the [Tutorial: Update a spreadsheet from a Power Automate flow](excel-power-automate-manual.md) tutorial. [Office Scripts use TypeScript](../overview/code-editor-environment.md) and this tutorial is intended for people with beginner to intermediate-level knowledge of JavaScript or TypeScript. If you're new to JavaScript, we recommend starting with the [Mozilla JavaScript tutorial](https://developer.mozilla.org/docs/Web/JavaScript/Guide/Introduction).
 
 ## Prerequisites
 
@@ -30,7 +30,7 @@ Power Automate shouldn't use [relative references](../testing/power-automate-tro
 
     ```TypeScript
     function main(workbook: ExcelScript.Workbook) {
-      // Add a new worksheet to store our email table
+      // Add a new worksheet to store the email table
       let emailsSheet = workbook.addWorksheet("Emails");
 
       // Add data and create a table
@@ -53,11 +53,11 @@ Power Automate shouldn't use [relative references](../testing/power-automate-tro
 
 ## Create an Office Script
 
-Let's create a script that logs information from an email. We want to know which days of the week we receive the most mail and how many unique senders are sending that mail. Our workbook has a table with **Date**, **Day of the week**, **Email address**, and **Subject** columns. Our worksheet also has a PivotTable that is pivoting on the **Day of the week** and **Email address** (those are the row hierarchies). The count of unique **Subjects** is the aggregated information being displayed (the data hierarchy). We'll have our script refresh that PivotTable after updating the email table.
+Create a script that logs information from an email. You'll want to track which days of the week you receive the most mail and how many unique senders are sending that mail. Your workbook has a table with **Date**, **Day of the week**, **Email address**, and **Subject** columns. Your worksheet also has a PivotTable that is pivoting on the **Day of the week** and **Email address** (those are the row hierarchies). The count of unique **Subjects** is the aggregated information being displayed (the data hierarchy). The script will refresh that PivotTable after it updates the email table.
 
 1. From within the Code Editor task pane, select **New Script**.
 
-2. The flow that you'll create later in the tutorial will send our script information about each email that's received. The script needs to accept that input through parameters in the `main` function. Replace the default script with the following script.
+2. The flow that you'll create later in the tutorial sends the script information about each email that's received. The script needs to accept that input through parameters in the `main` function. Replace the default script with the following script.
 
     ```TypeScript
     function main(
@@ -81,7 +81,7 @@ Let's create a script that logs information from an email. We want to know which
     let pivotTable = pivotTableWorksheet.getPivotTable("Pivot");
     ```
 
-4. The `dateReceived` parameter is of type `string`. Let's convert that to a [`Date` object](../develop/javascript-objects.md#date) so you can easily get the day of the week. After doing that, you'll need to map the day's number value to a more readable version. Add the following code to the end of your script, before the closing `}`.
+4. The `dateReceived` parameter is of type `string`. Convert that to a [`Date` object](../develop/javascript-objects.md#date) so you can easily get the day of the week. After doing that, you'll need to map the day's number value to a more readable version. Add the following code to the end of your script, before the closing `}`.
 
     ```TypeScript
       // Parse the received date string to determine the day of the week.
@@ -89,7 +89,7 @@ Let's create a script that logs information from an email. We want to know which
       let dayName = emailDate.toLocaleDateString("en-US", { weekday: 'long' });
     ```
 
-5. The `subject` string may include the "RE:" reply tag. Let's remove that from the string so that emails in the same thread have the same subject for the table. Add the following code to the end of your script, before the closing `}`.
+5. The `subject` string may include the "RE:" reply tag. Remove that from the string so that emails in the same thread have the same subject for the table. Add the following code to the end of your script, before the closing `}`.
 
     ```TypeScript
     // Remove the reply tag from the email subject to group emails on the same thread.
@@ -97,14 +97,14 @@ Let's create a script that logs information from an email. We want to know which
     subjectText = subjectText.replace("RE: ", "");
     ```
 
-6. Now that the email data has been formatted to our liking, let's add a row to the email table. Add the following code to the end of your script, before the closing `}`.
+6. Now that the email data has been formatted, add a row to the email table. Add the following code to the end of your script, before the closing `}`.
 
     ```TypeScript
     // Add the parsed text to the table.
     table.addRow(-1, [dateReceived, dayName, from, subjectText]);
     ```
 
-7. Finally, let's make sure the PivotTable is refreshed. Add the following code to the end of your script, before the closing `}`:
+7. Finally, make sure the PivotTable is refreshed. Add the following code to the end of your script, before the closing `}`:
 
     ```TypeScript
     // Refresh the PivotTable to include the new row.
@@ -220,6 +220,6 @@ Receiving multiple emails at the same time can cause merge conflicts in Excel. T
 
 ## Next steps
 
-Complete the [Return data from a script to an automatically-run Power Automate flow](excel-power-automate-returns.md) tutorial. It teaches you how to return data from a script to the flow.
+Complete the [Tutorial: Send email reminders every week based on spreadsheet data](excel-power-automate-returns.md) tutorial. It teaches you how to return data from a script to the flow.
 
 You can also check out the [Automated task reminders sample scenario](../resources/scenarios/task-reminders.md) to learn how to combine Office Scripts and Power Automate with Teams Adaptive Cards.

--- a/docs/tutorials/excel-power-automate-trigger.md
+++ b/docs/tutorials/excel-power-automate-trigger.md
@@ -10,7 +10,7 @@ ms.localizationpriority: high
 This tutorial teaches you how to use an Office Script for Excel with an automated [Power Automate](https://make.powerautomate.com) workflow. Your script will automatically run each time you receive an email, recording information from the email in an Excel workbook. Being able to pass data from other applications into an Office Script gives you a great deal of flexibility and freedom in your automated processes.
 
 > [!TIP]
-> If you're new to Office Scripts, we recommend starting with the [Tutorial: Create and format an Excel table](excel-tutorial.md) tutorial. If you're new to Power Automate, we recommend starting with the [Tutorial: Update a spreadsheet from a Power Automate flow](excel-power-automate-manual.md) tutorial. [Office Scripts use TypeScript](../overview/code-editor-environment.md) and this tutorial is intended for people with beginner to intermediate-level knowledge of JavaScript or TypeScript. If you're new to JavaScript, we recommend starting with the [Mozilla JavaScript tutorial](https://developer.mozilla.org/docs/Web/JavaScript/Guide/Introduction).
+> If you're new to Office Scripts, we recommend starting with [Tutorial: Create and format an Excel table](excel-tutorial.md). If you're new to Power Automate, we recommend starting with [Tutorial: Update a spreadsheet from a Power Automate flow](excel-power-automate-manual.md). [Office Scripts use TypeScript](../overview/code-editor-environment.md) and this tutorial is intended for people with beginner to intermediate-level knowledge of JavaScript or TypeScript. If you're new to JavaScript, we recommend starting with the [Mozilla JavaScript tutorial](https://developer.mozilla.org/docs/Web/JavaScript/Guide/Introduction).
 
 ## Prerequisites
 
@@ -30,7 +30,7 @@ Power Automate shouldn't use [relative references](../testing/power-automate-tro
 
     ```TypeScript
     function main(workbook: ExcelScript.Workbook) {
-      // Add a new worksheet to store the email table
+      // Add a new worksheet to store the email table.
       let emailsSheet = workbook.addWorksheet("Emails");
 
       // Add data and create a table
@@ -220,6 +220,6 @@ Receiving multiple emails at the same time can cause merge conflicts in Excel. T
 
 ## Next steps
 
-Complete the [Tutorial: Send weekly email reminders based on spreadsheet data](excel-power-automate-returns.md) tutorial. It teaches you how to return data from a script to the flow.
+Complete [Tutorial: Send weekly email reminders based on spreadsheet data](excel-power-automate-returns.md). It teaches you how to return data from a script to the flow.
 
 You can also check out the [Automated task reminders sample scenario](../resources/scenarios/task-reminders.md) to learn how to combine Office Scripts and Power Automate with Teams Adaptive Cards.

--- a/docs/tutorials/excel-power-automate-trigger.md
+++ b/docs/tutorials/excel-power-automate-trigger.md
@@ -220,6 +220,6 @@ Receiving multiple emails at the same time can cause merge conflicts in Excel. T
 
 ## Next steps
 
-Complete the [Tutorial: Send email reminders every week based on spreadsheet data](excel-power-automate-returns.md) tutorial. It teaches you how to return data from a script to the flow.
+Complete the [Tutorial: Send weekly email reminders based on spreadsheet data](excel-power-automate-returns.md) tutorial. It teaches you how to return data from a script to the flow.
 
 You can also check out the [Automated task reminders sample scenario](../resources/scenarios/task-reminders.md) to learn how to combine Office Scripts and Power Automate with Teams Adaptive Cards.

--- a/docs/tutorials/excel-read-tutorial.md
+++ b/docs/tutorials/excel-read-tutorial.md
@@ -10,7 +10,7 @@ ms.localizationpriority: high
 This tutorial teaches you how to read data from a workbook with an Office Script for Excel. You'll be writing a new script that formats a bank statement and normalizes the data in that statement. As part of that data clean-up, your script will read values from the transaction cells, apply a simple formula to each value, and write the resulting answer to the workbook. Reading data from the workbook lets you automate some of your decision making processes in the script.
 
 > [!TIP]
-> If you're new to Office Scripts, we recommend starting with the [Tutorial: Create and format an Excel table](excel-tutorial.md) tutorial. [Office Scripts use TypeScript](../overview/code-editor-environment.md) and this tutorial is intended for people with beginner to intermediate-level knowledge of JavaScript or TypeScript. If you're new to JavaScript, we recommend starting with the [Mozilla JavaScript tutorial](https://developer.mozilla.org/docs/Web/JavaScript/Guide/Introduction).
+> If you're new to Office Scripts, we recommend starting with [Tutorial: Create and format an Excel table](excel-tutorial.md). [Office Scripts use TypeScript](../overview/code-editor-environment.md) and this tutorial is intended for people with beginner to intermediate-level knowledge of JavaScript or TypeScript. If you're new to JavaScript, we recommend starting with the [Mozilla JavaScript tutorial](https://developer.mozilla.org/docs/Web/JavaScript/Guide/Introduction).
 
 ## Prerequisites
 
@@ -144,4 +144,4 @@ Now that you know how to read and write to a single cell, you can generalize the
 
 Open the Code Editor and try out some of our [Sample scripts for Office Scripts in Excel](../resources/samples/excel-samples.md). You can also visit [Fundamentals for Office Scripts in Excel](../develop/scripting-fundamentals.md) to learn more about creating Office Scripts.
 
-The next series of Office Scripts tutorials focus on using Office Scripts with Power Automate. Learn more about the advantages combining the two platforms in [Run Office Scripts with Power Automate](../develop/power-automate-integration.md) or try the [Tutorial: Update a spreadsheet from a Power Automate flow](excel-power-automate-manual.md) tutorial to create a Power Automate flow that uses an Office Script.
+The next series of Office Scripts tutorials focus on using Office Scripts with Power Automate. Learn more about the advantages combining the two platforms in [Run Office Scripts with Power Automate](../develop/power-automate-integration.md) or try [Tutorial: Update a spreadsheet from a Power Automate flow](excel-power-automate-manual.md) to create a Power Automate flow that uses an Office Script.

--- a/docs/tutorials/excel-read-tutorial.md
+++ b/docs/tutorials/excel-read-tutorial.md
@@ -1,16 +1,16 @@
 ---
-title: Read workbook data with Office Scripts in Excel
+title: 'Tutorial: Clean and normalize Excel workbook data'
 description: An Office Scripts tutorial about reading data from workbooks and evaluating that data in the script.
-ms.date: 10/01/2022
+ms.date: 11/14/2023
 ms.localizationpriority: high
 ---
 
-# Read workbook data with Office Scripts in Excel
+# Tutorial: Clean and normalize Excel workbook data
 
 This tutorial teaches you how to read data from a workbook with an Office Script for Excel. You'll be writing a new script that formats a bank statement and normalizes the data in that statement. As part of that data clean-up, your script will read values from the transaction cells, apply a simple formula to each value, and write the resulting answer to the workbook. Reading data from the workbook lets you automate some of your decision making processes in the script.
 
 > [!TIP]
-> If you're new to Office Scripts, we recommend starting with the [Record, edit, and create Office Scripts in Excel](excel-tutorial.md) tutorial. [Office Scripts use TypeScript](../overview/code-editor-environment.md) and this tutorial is intended for people with beginner to intermediate-level knowledge of JavaScript or TypeScript. If you're new to JavaScript, we recommend starting with the [Mozilla JavaScript tutorial](https://developer.mozilla.org/docs/Web/JavaScript/Guide/Introduction).
+> If you're new to Office Scripts, we recommend starting with the [Tutorial: Create and format an Excel table](excel-tutorial.md) tutorial. [Office Scripts use TypeScript](../overview/code-editor-environment.md) and this tutorial is intended for people with beginner to intermediate-level knowledge of JavaScript or TypeScript. If you're new to JavaScript, we recommend starting with the [Mozilla JavaScript tutorial](https://developer.mozilla.org/docs/Web/JavaScript/Guide/Introduction).
 
 ## Prerequisites
 
@@ -144,4 +144,4 @@ Now that you know how to read and write to a single cell, you can generalize the
 
 Open the Code Editor and try out some of our [Sample scripts for Office Scripts in Excel](../resources/samples/excel-samples.md). You can also visit [Fundamentals for Office Scripts in Excel](../develop/scripting-fundamentals.md) to learn more about creating Office Scripts.
 
-The next series of Office Scripts tutorials focus on using Office Scripts with Power Automate. Learn more about the advantages combining the two platforms in [Run Office Scripts with Power Automate](../develop/power-automate-integration.md) or try the [Call scripts from a manual Power Automate flow](excel-power-automate-manual.md) tutorial to create a Power Automate flow that uses an Office Script.
+The next series of Office Scripts tutorials focus on using Office Scripts with Power Automate. Learn more about the advantages combining the two platforms in [Run Office Scripts with Power Automate](../develop/power-automate-integration.md) or try the [Tutorial: Update a spreadsheet from a Power Automate flow](excel-power-automate-manual.md) tutorial to create a Power Automate flow that uses an Office Script.

--- a/docs/tutorials/excel-tutorial.md
+++ b/docs/tutorials/excel-tutorial.md
@@ -1,11 +1,11 @@
----
-title: Record, edit, and create Office Scripts in Excel
+--- 
+title: "Tutorial: Create and format an Excel table"
 description: A tutorial about the basics of Office Scripts, including recording scripts with the Action Recorder and writing data to a workbook.
-ms.date: 03/27/2023
+ms.date: 11/14/2023
 ms.localizationpriority: high
 ---
 
-# Record, edit, and create Office Scripts in Excel
+# Tutorial: Create and format an Excel table
 
 This tutorial teaches you the basics of recording, editing, and writing an Office Script for Excel. You'll record a script that applies some formatting to a sales record worksheet. You'll then edit the recorded script to apply more formatting, create a table, and sort that table. This record-then-edit pattern is an important tool to see what your Excel actions look like as code.
 
@@ -21,7 +21,7 @@ This tutorial teaches you the basics of recording, editing, and writing an Offic
 First, you'll need some data and a small starting script.
 
 1. Create a new Excel workbook.
-2. Copy the following fruit sales data and paste it into the worksheet, starting at cell **A1**.
+1. Copy the following fruit sales data and paste it into the worksheet, starting at cell **A1**.
 
     |Fruit |2018 |2019 |
     |:---|:---|:---|
@@ -30,10 +30,10 @@ First, you'll need some data and a small starting script.
     |Limes |600 |500 |
     |Grapefruits |900 |700 |
 
-3. Open the **Automate** tab. If you don't see the **Automate** tab, check the ribbon overflow by selecting the drop-down arrow. If it's still not there, follow the advice in the article [Troubleshoot Office Scripts](../testing/troubleshooting.md#automate-tab-not-appearing-or-office-scripts-unavailable).
-4. Select the **Record Actions** button.
-5. Select cells **A2:C2** (the "Oranges" row) and set the fill color to orange.
-6. Stop the recording by selecting the **Stop** button.
+1. Open the **Automate** tab. If you don't see the **Automate** tab, check the ribbon overflow by selecting the drop-down arrow. If it's still not there, follow the advice in the article [Troubleshoot Office Scripts](../testing/troubleshooting.md#automate-tab-not-appearing-or-office-scripts-unavailable).
+1. Select the **Record Actions** button.
+1. Select cells **A2:C2** (the "Oranges" row) and set the fill color to orange.
+1. Stop the recording by selecting the **Stop** button.
 
     Your worksheet should look like this (don't worry if the color is different):
 
@@ -41,10 +41,10 @@ First, you'll need some data and a small starting script.
 
 ## Edit an existing script
 
-The previous script colored the "Oranges" row to be orange. Let's add a yellow row for the "Lemons".
+The previous script colored the "Oranges" row to be orange. Add a yellow row for the "Lemons".
 
 1. From the now-open **Details** pane, select the **Edit** button.
-2. You should see something similar to this code:
+1. You should see something similar to this code:
 
     ```TypeScript
     function main(workbook: ExcelScript.Workbook) {
@@ -58,19 +58,19 @@ The previous script colored the "Oranges" row to be orange. Let's add a yellow r
 
     Ranges are a fundamental part of Office Scripts in Excel. A range is a contiguous, rectangular block of cells that contains values, formula, and formatting. They are the basic structure of cells through which you'll perform most of your scripting tasks.
 
-3. Add the following line to the end of the script (between where the `color` is set and the closing `}`):
+1. Add the following line to the end of the script (between where the `color` is set and the closing `}`):
 
     ```TypeScript
     selectedSheet.getRange("A3:C3").getFormat().getFill().setColor("yellow");
     ```
 
-4. Test the script by selecting **Run**. Your workbook should now look like this:
+1. Test the script by selecting **Run**. Your workbook should now look like this:
 
     :::image type="content" source="../images/tutorial-2.png" alt-text="A worksheet showing the fruit sales data row with the 'Oranges' row highlighted in the color orange and the 'Lemons' row highlighted in the color yellow.":::
 
 ## Create a table
 
-Let's convert this fruit sales data into a table. We'll use our script for the entire process.
+Next, convert this fruit sales data into a table. You'll keep modifying the first script for the entire tutorial.
 
 1. Add the following line to the end of the script (before the closing `}`):
 
@@ -78,7 +78,7 @@ Let's convert this fruit sales data into a table. We'll use our script for the e
     let table = selectedSheet.addTable("A1:C5", true);
     ```
 
-2. That call returns a `Table` object. Let's use that table to sort the data. We'll sort the data in ascending order based on the values in the "Fruit" column. Add the following line after the table creation:
+1. That call returns a `Table` object. Use that table to sort the data.Sort the data in ascending order based on the values in the "Fruit" column. Add the following line after the table creation:
 
     ```TypeScript
     table.getSort().apply([{ key: 0, ascending: true }]);
@@ -99,7 +99,7 @@ Let's convert this fruit sales data into a table. We'll use our script for the e
 
     Tables have a `TableSort` object, accessed through the `Table.getSort` method. You can apply sorting criteria to that object. The `apply` method takes in an array of `SortField` objects. In this case, you only have one sorting criteria, so you only use one `SortField`. `key: 0` sets the column with the sort-defining values to "0" (which is the first column on the table, **A** in this case). `ascending: true` sorts the data in ascending order (instead of descending order).
 
-3. Run the script. You should see a table like this:
+1. Run the script. You should see a table like this:
 
     :::image type="content" source="../images/tutorial-3.png" alt-text="A worksheet showing the sorted fruit sales table.":::
 
@@ -109,9 +109,9 @@ Let's convert this fruit sales data into a table. We'll use our script for the e
 ### Re-run the script
 
 1. Create a new worksheet in the current workbook.
-2. Copy the fruit data from the beginning of the tutorial and paste it into the new worksheet, starting at cell **A1**.
-3. Run the script.
+1. Copy the fruit data from the beginning of the tutorial and paste it into the new worksheet, starting at cell **A1**.
+1. Run the script.
 
 ## Next steps
 
-Complete the [Read workbook data with Office Scripts in Excel](excel-read-tutorial.md) tutorial. It teaches you how to read data from a workbook with an Office Script.
+Complete the [Tutorial: Clean and normalize Excel workbook data](excel-read-tutorial.md) tutorial. It teaches you how to read data from a workbook with an Office Script.

--- a/docs/tutorials/excel-tutorial.md
+++ b/docs/tutorials/excel-tutorial.md
@@ -1,4 +1,4 @@
---- 
+---
 title: "Tutorial: Create and format an Excel table"
 description: A tutorial about the basics of Office Scripts, including recording scripts with the Action Recorder and writing data to a workbook.
 ms.date: 11/14/2023

--- a/docs/tutorials/excel-tutorial.md
+++ b/docs/tutorials/excel-tutorial.md
@@ -114,4 +114,4 @@ Next, convert this fruit sales data into a table. You'll keep modifying the firs
 
 ## Next steps
 
-Complete the [Tutorial: Clean and normalize Excel workbook data](excel-read-tutorial.md) tutorial. It teaches you how to read data from a workbook with an Office Script.
+Complete [Tutorial: Clean and normalize Excel workbook data](excel-read-tutorial.md). It teaches you how to read data from a workbook with an Office Script.


### PR DESCRIPTION
In an effort to drive tutorial usage, this PR adjusts the titles of the tutorial to focus on the task being achieved, rather than the skill being taught.

This PR also adjusts some of the language in the tutorials to focus on the reader, not the author ("you" instead of "we").