### PR TITLE
[all] (support) Remove mention of COM support for Mac

### DIFF
--- a/docs/includes/platform-support-table.md
+++ b/docs/includes/platform-support-table.md
@@ -4,4 +4,4 @@
 | **Office Scripts Action Recorder** | Yes | Yes | Yes | No | No | No |
 | **VBA macros** | No | Yes | Yes | No | Yes | No |
 | **Office Add-ins** | Yes | Yes | Yes | Yes | Yes | No |
-| **COM Add-ins** | No | Yes | Yes | No | Yes | No |
+| **COM Add-ins** | No | Yes | No | No | Yes | No |


### PR DESCRIPTION
Fixes #743.
 
COM add-ins are not supported on Mac, so this table is misleading.

Tagging @davidchesnut for a sanity check.