### PR TITLE
[excel] (TOC) Move samples node

### DIFF
--- a/docs/overview/excel.md
+++ b/docs/overview/excel.md
@@ -76,6 +76,7 @@ Complete the [Office Scripts in Excel tutorial](../tutorials/excel-tutorial.md) 
 ## See also
 
 - [Fundamentals for Office Scripts in Excel](../develop/scripting-fundamentals.md)
+- [Office Scripts samples and scenarios](../resources/samples/samples-overview.md)
 - [Office Scripts API reference](/javascript/api/office-scripts/overview)
 - [Platform limits and requirements with Office Scripts](../testing/platform-limits.md)
 - [Office Scripts settings in M365](/microsoft-365/admin/manage/manage-office-scripts-settings)

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -3,6 +3,7 @@ items:
   href: index.yml
 
 - name: Office Scripts in Excel
+  expanded: true
   items:
   - name: Overview
     href: overview/excel.md

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -47,20 +47,6 @@ items:
       href: develop/macros-power-automate.md
     - name: Work with PivotTables
       href: develop/pivottables.md
-  - name: Troubleshooting
-    items:
-    - name: Troubleshooting basics
-      href: testing/troubleshooting.md
-    - name: Troubleshooting with Power Automate
-      href: testing/power-automate-troubleshooting.md
-    - name: Improve script performance
-      href: develop/web-client-performance.md
-    - name: Platform limits
-      href: testing/platform-limits.md
-    - name: TypeScript restrictions
-      href: develop/typescript-restrictions.md
-    - name: Undo the effects of Office Scripts
-      href: testing/undo.md
   - name: Samples
     items:
     - name: Overview
@@ -139,6 +125,20 @@ items:
         href: resources/scenarios/punch-clock.md
       - name: Seasons greetings
         href: resources/samples/community-seasons-greetings.md
+  - name: Troubleshooting
+    items:
+    - name: Troubleshooting basics
+      href: testing/troubleshooting.md
+    - name: Troubleshooting with Power Automate
+      href: testing/power-automate-troubleshooting.md
+    - name: Improve script performance
+      href: develop/web-client-performance.md
+    - name: Platform limits
+      href: testing/platform-limits.md
+    - name: TypeScript restrictions
+      href: develop/typescript-restrictions.md
+    - name: Undo the effects of Office Scripts
+      href: testing/undo.md
   - name: Office Scripts and other platforms
     items:
     - name: Differences between Office Scripts and VBA Macros

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -48,6 +48,7 @@ items:
     - name: Work with PivotTables
       href: develop/pivottables.md
   - name: Samples
+    expanded: true
     items:
     - name: Overview
       href: resources/samples/samples-overview.md


### PR DESCRIPTION
The goal of this PR is to make the samples more discoverable. It does three things: 
- Moves the Samples node above Troubleshooting 
- Sets the TOC node "Office Scripts in Excel" to always be expanded 
- Sets the "Samples" node to always be expanded -- curious about feedback on this one 