### PR TITLE
[excel] (Samples) Add explicit note about opening the code editor to all samples

### DIFF
--- a/docs/includes/open-code-editor-single-script.md
+++ b/docs/includes/open-code-editor-single-script.md
@@ -1,0 +1,1 @@
+Run the following script in the sample workbook and try the sample yourself! Open the Code Editor by going to **Automate** > **New Script** > **Create in Code Editor**, replace the default code with the sample code you want to run, and then select **Run**.

--- a/docs/includes/open-code-editor.md
+++ b/docs/includes/open-code-editor.md
@@ -1,0 +1,2 @@
+> [!NOTE]
+> Run these samples directly from the Office Scripts Code Editor. To open the Code Editor, go to **Automate** > **New Script** > **Create in Code Editor**. Replace the default code with the sample code you want to run, and then select **Run**.

--- a/docs/resources/samples/add-image-to-workbook.md
+++ b/docs/resources/samples/add-image-to-workbook.md
@@ -1,7 +1,7 @@
 ---
 title: Add images to a workbook
 description: Learn how to use Office Scripts to add an image to a workbook and copy it across sheets.
-ms.date: 04/27/2023
+ms.date: 12/22/2025
 ms.localizationpriority: medium
 ---
 
@@ -26,7 +26,7 @@ This workbook contains the data, objects, and formatting expected by the script.
 
 ## Sample code: Copy an image across worksheets
 
-Add the following script to the sample workbook and try the sample yourself!
+[!INCLUDE [open-code-editor-single-script](../../includes/open-code-editor-single-script.md)]
 
 ```TypeScript
 /**

--- a/docs/resources/samples/automate-tasks-on-all-excel-files-in-folder.md
+++ b/docs/resources/samples/automate-tasks-on-all-excel-files-in-folder.md
@@ -1,7 +1,7 @@
 ---
 title: Run a script on all Excel files in a folder
 description: Learn how to run a script on all the Excel files in a folder on OneDrive for Business.
-ms.date: 11/30/2023
+ms.date: 12/22/2025
 ms.localizationpriority: medium
 ---
 
@@ -16,7 +16,7 @@ Download <a href="https://github.com/OfficeDev/office-scripts-docs/blob/master/d
 
 ## Sample code: Add formatting and insert comment
 
-This is the script that runs on each individual workbook. In Excel, use **Automate** > **New Script** to paste the code and save the script. Save it as **Review script** and try the sample yourself!
+This is the script that runs on each individual workbook. In Excel, use **Automate** > **New Script** > **Create in Code Editor** to paste the code and save the script. Save it as **Review script** and try the sample yourself!
 
 ```TypeScript
 function main(workbook: ExcelScript.Workbook) {

--- a/docs/resources/samples/chart-samples.md
+++ b/docs/resources/samples/chart-samples.md
@@ -1,13 +1,15 @@
 ---
 title: 'Charts: Create and customize Excel charts with Office Scripts'
 description: A collection of code samples showing how to create and customize different types of Excel charts in Office Scripts.
-ms.date: 11/20/2025
+ms.date: 12/22/2025
 ms.localizationpriority: medium
 ---
 
 # Charts: Create and customize Excel charts with Office Scripts
 
 This article demonstrates how to create every type of Excel chart that Office Scripts supports. Each sample includes data and showcases APIs specific to that chart type. Use these samples as starting points for your own charting solutions.
+
+[!INCLUDE [open-code-editor](../../includes/open-code-editor.md)]
 
 > [!TIP]
 > For the best results, run each sample on an empty worksheet.

--- a/docs/resources/samples/community-seasons-greetings.md
+++ b/docs/resources/samples/community-seasons-greetings.md
@@ -1,7 +1,7 @@
 ---
 title: Seasons greetings
 description: Learn how to use Office Scripts to show a singing tree in Excel.
-ms.date: 06/29/2021
+ms.date: 12/22/2025
 ms.localizationpriority: medium
 ---
 
@@ -22,7 +22,7 @@ This workbook contains the data, objects, and formatting expected by the script.
 
 ## Sample code: Happy tree
 
-Add the following script to the sample workbook and try the sample yourself!
+[!INCLUDE [open-code-editor-single-script](../../includes/open-code-editor-single-script.md)]
 
 ```TypeScript
 /* Original version by Leslie Black.  */

--- a/docs/resources/samples/conditional-formatting-parameters.md
+++ b/docs/resources/samples/conditional-formatting-parameters.md
@@ -1,7 +1,7 @@
 ---
 title: Set conditional formatting for cross-column comparisons
 description: Learn how to apply conditional formatting and get input from the user.
-ms.date: 09/07/2023
+ms.date: 12/22/2025
 ms.localizationpriority: medium
 ---
 
@@ -10,6 +10,8 @@ ms.localizationpriority: medium
 This sample shows how to apply conditional formatting to a range. The conditions used are comparing values to those in an adjacent column.  Additionally, this sample uses [parameters to get user input](../../develop/user-input.md). This lets the person running the script select the range, the type of comparison, and the colors.
 
 ## Sample code: Set conditional formatting
+
+[!INCLUDE [open-code-editor-single-script](../../includes/open-code-editor-single-script.md)]
 
 ```TypeScript
 /**

--- a/docs/resources/samples/conditional-formatting-samples.md
+++ b/docs/resources/samples/conditional-formatting-samples.md
@@ -1,7 +1,7 @@
 ---
 title: Conditional formatting samples
 description: A collection of Office Scripts that use different Excel conditional formatting options.
-ms.date: 12/28/2023
+ms.date: 12/22/2025
 ms.localizationpriority: medium
 ---
 
@@ -13,6 +13,9 @@ This sample workbook contains worksheets ready to test with the sample scripts.
 
 > [!div class="nextstepaction"]
 > [Download the sample workbook](conditional-formatting-samples.xlsx)
+
+
+[!INCLUDE [open-code-editor](../../includes/open-code-editor.md)]
 
 ## Cell value
 

--- a/docs/resources/samples/convert-csv.md
+++ b/docs/resources/samples/convert-csv.md
@@ -1,7 +1,7 @@
 ---
 title: Convert CSV files to Excel workbooks
 description: Learn how to use Office Scripts and Power Automate to create .xlsx files from .csv files.
-ms.date: 02/07/2024
+ms.date: 12/22/2025
 ms.localizationpriority: medium
 ---
 
@@ -19,7 +19,7 @@ Many services export data as comma-separated value (CSV) files. This solution au
 
 Download <a href="https://github.com/OfficeDev/office-scripts-docs/blob/master/docs/resources/samples/convert-csv-example.zip?raw=true">convert-csv-example.zip</a> to get the Template.xlsx file and two sample .csv files. Extract the files into a folder in your OneDrive. This sample assumes the folder is named "output".
 
-Add the following script to the sample workbook. In Excel, use **Automate** > **New Script** to paste the code and save the script. Save it as **Convert CSV** and try the sample yourself!
+Add the following script to the sample workbook. In Excel, use **Automate** > **New Script** > **Create in Code Editor** to paste the code and save the script. Save it as **Convert CSV** and try the sample yourself!
 
 ## Sample code: Insert comma-separated values into a workbook
 

--- a/docs/resources/samples/copy-tables-combine.md
+++ b/docs/resources/samples/copy-tables-combine.md
@@ -1,7 +1,7 @@
 ---
 title: Combine data from multiple Excel tables into a single table
 description: Learn how to use Office Scripts to combine data from multiple Excel tables into a single table.
-ms.date: 08/14/2025
+ms.date: 12/22/2025
 ms.localizationpriority: medium
 ---
 
@@ -13,6 +13,8 @@ There are two variations of this script:
 
 1. The [first script](#sample-code-combine-data-from-multiple-excel-tables-into-a-single-table) combines all tables in the Excel file.
 1. The [second script](#sample-code-combine-data-from-multiple-excel-tables-in-select-worksheets-into-a-single-table) selectively gets tables within a set of worksheets.
+1. 
+[!INCLUDE [open-code-editor](../../includes/open-code-editor.md)]
 
 ## Setup: Sample Excel file
 

--- a/docs/resources/samples/count-blank-rows.md
+++ b/docs/resources/samples/count-blank-rows.md
@@ -1,7 +1,7 @@
 ---
 title: Count blank rows on sheets
 description: Learn how to use Office Scripts to detect if there are any blank rows instead of data in worksheets and then report the blank row count to be used in a Power Automate flow.
-ms.date: 06/29/2021
+ms.date: 12/22/2025
 ms.localizationpriority: medium
 ---
 
@@ -22,6 +22,8 @@ _This sheet returns count of 4 blank rows_
 _This sheet returns count of 0 blank rows (all rows have some data)_
 
 :::image type="content" source="../../images/no-blank-rows.png" alt-text="A worksheet showing data without blank rows.":::
+
+[!INCLUDE [open-code-editor](../../includes/open-code-editor.md)]
 
 ## Sample code: Count blank rows on a given sheet
 

--- a/docs/resources/samples/data-validation-samples.md
+++ b/docs/resources/samples/data-validation-samples.md
@@ -1,13 +1,15 @@
 ---
 title: "Data validation: dropdown lists, prompts, and warning pop-ups"
 description: Learn how to add data validation to a cell and give the user a selection of values to enter.
-ms.date: 09/20/2023
+ms.date: 12/22/2025
 ms.localizationpriority: medium
 ---
 
 # Data validation: dropdown lists, prompts, and warning pop-ups
 
 Data validation helps the user ensure consistency in a worksheet. Use these features to limit what can be entered into a cell and provide warnings or errors to users when those conditions aren't met. To learn more about data validation in Excel, see [Apply data validation to cells](https://support.microsoft.com/office/29fecbcc-d1b9-42c1-9d76-eff3ce5f7249).
+
+[!INCLUDE [open-code-editor](../../includes/open-code-editor.md)]
 
 ## Create a dropdown list using data validation
 

--- a/docs/resources/samples/email-images-chart-table.md
+++ b/docs/resources/samples/email-images-chart-table.md
@@ -1,7 +1,7 @@
 ---
 title: Email the images of an Excel chart and table
 description: Learn how to use Office Scripts and Power Automate to extract and email the images of an Excel chart and table.
-ms.date: 05/21/2024
+ms.date: 12/22/2025
 ms.localizationpriority: medium
 ---
 
@@ -44,7 +44,7 @@ This workbook contains the data, objects, and formatting expected by the script.
 
 ## Sample code: Calculate and extract Excel chart and table
 
-Add the following script to the sample workbook. In Excel, use **Automate** > **New Script** to paste the code and save the script. Save it as **Get chart image** and try the sample yourself!
+Add the following script to the sample workbook. In Excel, use **Automate** > **New Script** > **Create in Code Editor** to paste the code and save the script. Save it as **Get chart image** and try the sample yourself!
 
 ```TypeScript
 function main(workbook: ExcelScript.Workbook): ReportImages {

--- a/docs/resources/samples/excel-calculation.md
+++ b/docs/resources/samples/excel-calculation.md
@@ -1,7 +1,7 @@
 ---
 title: Manage calculation mode in Excel
 description: Learn how to use Office Scripts to manage the calculation mode in Excel.
-ms.date: 05/06/2021
+ms.date: 12/22/2025
 ms.localizationpriority: medium
 ---
 
@@ -16,6 +16,8 @@ Workbooks with large numbers of formulas can take a while to recalculate. Rather
 The sample script sets the calculation mode to manual. This means that the workbook will only recalculate formulas when the script tells it to (or you [manually calculate through the UI](https://support.microsoft.com/office/73fc7dac-91cf-4d36-86e8-67124f6bcce4)). The script then displays the current calculation mode and fully recalculates the entire workbook.
 
 ## Sample code: Control calculation mode
+
+[!INCLUDE [open-code-editor-single-script](../../includes/open-code-editor-single-script.md)]
 
 ```TypeScript
 function main(workbook: ExcelScript.Workbook) {

--- a/docs/resources/samples/excel-cross-reference.md
+++ b/docs/resources/samples/excel-cross-reference.md
@@ -1,7 +1,7 @@
 ---
 title: Cross-reference Excel files with Power Automate
 description: Learn how to use Office Scripts and Power Automate to cross-reference and format an Excel file.
-ms.date: 11/30/2023
+ms.date: 12/22/2025
 ms.localizationpriority: medium
 ---
 
@@ -22,7 +22,7 @@ Download the following files to get ready-to-use workbooks for the sample.
 1. [event-data.xlsx](event-data.xlsx)
 1. [speaker-registrations.xlsx](speaker-registrations.xlsx)
 
-Add the following scripts to try the sample yourself! In Excel, use **Automate** > **New Script** to paste the code and save the scripts with the suggested names.
+Add the following scripts to try the sample yourself! In Excel, use **Automate** > **New Script** > **Create in Code Editor** to paste the code and save the scripts with the suggested names.
 
 ## Sample code: Get event data
 

--- a/docs/resources/samples/external-fetch-calls.md
+++ b/docs/resources/samples/external-fetch-calls.md
@@ -1,7 +1,7 @@
 ---
 title: Use external fetch calls in Office Scripts
 description: Learn how to make external API calls in Office Scripts.
-ms.date: 06/10/2022
+ms.date: 12/22/2025
 ms.localizationpriority: medium
 ---
 
@@ -14,6 +14,8 @@ Learn more about the GitHub APIs being used in the [GitHub API reference](https:
 ![Get repositories info example](../../images/git.png)
 
 ## Sample code: Get basic information about user's GitHub repositories
+
+[!INCLUDE [open-code-editor-single-script](../../includes/open-code-editor-single-script.md)]
 
 ```TypeScript
 async function main(workbook: ExcelScript.Workbook) {

--- a/docs/resources/samples/get-table-data.md
+++ b/docs/resources/samples/get-table-data.md
@@ -1,7 +1,7 @@
 ---
 title: Output Excel data as JSON
 description: Learn how to output Excel table data as JSON to use in Power Automate.
-ms.date: 11/04/2022
+ms.date: 12/22/2025
 ms.localizationpriority: medium
 ---
 
@@ -24,7 +24,7 @@ A variation of this sample also includes the hyperlinks in one of the table colu
 
 ## Sample code: Return table data as JSON
 
-Add the following script to the sample workbook and try the sample yourself!
+[!INCLUDE [open-code-editor-single-script](../../includes/open-code-editor-single-script.md)]
 
 > [!NOTE]
 > You can change the `interface TableData` structure to match your table columns. Note that for column names with spaces, be sure to place your key in quotation marks, such as with `"Event ID"` in the sample. For more information about working with JSON, read [Use JSON to pass data to and from Office Scripts](../../develop/use-json.md).

--- a/docs/resources/samples/javascript-dates.md
+++ b/docs/resources/samples/javascript-dates.md
@@ -1,13 +1,15 @@
 ---
 title: JavaScript Date samples
 description: A collection of samples on how to use JavaScript Date objects with Excel.
-ms.date: 09/08/2023
+ms.date: 12/22/2025
 ms.localizationpriority: medium
 ---
 
 # JavaScript `Date` samples
 
 These samples show how to use the JavaScript [Date](https://developer.mozilla.org/docs/web/javascript/reference/global_objects/date) object.
+
+[!INCLUDE [open-code-editor](../../includes/open-code-editor.md)]
 
 ## Write the current date and time
 

--- a/docs/resources/samples/move-rows-across-tables.md
+++ b/docs/resources/samples/move-rows-across-tables.md
@@ -1,7 +1,7 @@
 ---
 title: Move rows across tables using Office Scripts
 description: Learn how to move rows across tables by saving filters, then processing and reapplying the filters.
-ms.date: 06/29/2021
+ms.date: 12/22/2025
 ms.localizationpriority: medium
 ---
 
@@ -22,7 +22,7 @@ This workbook contains the data, objects, and formatting expected by the script.
 
 ## Sample code: Move rows using range values
 
-Add the following script to the sample workbook and try the sample yourself!
+[!INCLUDE [open-code-editor-single-script](../../includes/open-code-editor-single-script.md)]
 
 ```TypeScript
 function main(workbook: ExcelScript.Workbook) {

--- a/docs/resources/samples/range-samples.md
+++ b/docs/resources/samples/range-samples.md
@@ -1,13 +1,15 @@
 ---
 title: 'Ranges: Work with the grid in Office Scripts'
 description: A collection of code samples showing how to work with Excel ranges, collections of cells, in Office Scripts.
-ms.date: 12/05/2023
+ms.date: 12/22/2025
 ms.localizationpriority: medium
 ---
 
 # Ranges: Work with the grid in Office Scripts
 
 The following samples are simple scripts for you to try on your own workbooks. They form the building blocks to larger solutions. Expand these scripts to extend your solution and solve common problems.
+
+[!INCLUDE [open-code-editor](../../includes/open-code-editor.md)]
 
 ## Read and log one cell
 

--- a/docs/resources/samples/remove-hyperlinks-from-cells.md
+++ b/docs/resources/samples/remove-hyperlinks-from-cells.md
@@ -1,7 +1,7 @@
 ---
 title: Remove hyperlinks from each cell in an Excel worksheet
 description: Learn how to use Office Scripts to remove hyperlinks from each cell in an Excel worksheet.
-ms.date: 06/29/2021
+ms.date: 12/22/2025
 ms.localizationpriority: medium
 ---
 
@@ -21,7 +21,7 @@ This workbook contains the data, objects, and formatting expected by the script.
 
 ## Sample code: Remove hyperlinks
 
-Add the following script to the sample workbook and try the sample yourself!
+[!INCLUDE [open-code-editor-single-script](../../includes/open-code-editor-single-script.md)]
 
 ```TypeScript
 function main(workbook: ExcelScript.Workbook, sheetName: string = 'Sheet1') {

--- a/docs/resources/samples/report-day-to-day-changes.md
+++ b/docs/resources/samples/report-day-to-day-changes.md
@@ -1,7 +1,7 @@
 ---
 title: Record day-to-day changes in Excel and report them with a Power Automate flow
 description: Learn how to use Office Scripts and Power Automate to track value changes in a workbook
-ms.date: 11/29/2023
+ms.date: 12/22/2025
 ms.localizationpriority: medium
 ---
 
@@ -18,7 +18,7 @@ This workbook contains the data, objects, and formatting expected by the script.
 
 ## Sample code: Record and report daily readings
 
-Add the following script to the sample workbook. In Excel, use **Automate** > **New Script** to paste the code and save the script. Save it as **Record daily value** and try the sample yourself!
+Add the following script to the sample workbook. In Excel, use **Automate** > **New Script** > **Create in Code Editor** to paste the code and save the script. Save it as **Record daily value** and try the sample yourself!
 
 ```TypeScript
 function main(workbook: ExcelScript.Workbook, newData: string): string {

--- a/docs/resources/samples/row-and-column-visibility.md
+++ b/docs/resources/samples/row-and-column-visibility.md
@@ -1,13 +1,15 @@
 ---
 title: Row and column visibility samples
 description: A collection of samples that show the basics of visibility in Excel.
-ms.date: 09/08/2023
+ms.date: 12/22/2025
 ms.localizationpriority: medium
 ---
 
 # Row and column visibility samples
 
 These samples demonstrate how to show, hide, and freeze rows and columns.
+
+[!INCLUDE [open-code-editor](../../includes/open-code-editor.md)]
 
 ## Hide columns
 

--- a/docs/resources/samples/save-as-pdf-email-as-pdf.md
+++ b/docs/resources/samples/save-as-pdf-email-as-pdf.md
@@ -1,7 +1,7 @@
 ---
 title: Save and email as a PDF
 description: Use Office Scripts to save a worksheet as a PDF and then email that PDF.
-ms.date: 12/04/2025
+ms.date: 12/22/2025
 ms.localizationpriority: medium
 ---
 
@@ -19,6 +19,8 @@ Use Office Scripts to save a worksheet as a PDF and email it to yourself or your
 1. Run the script.
 
 ## Sample code: Save as a PDF and send via email
+
+[!INCLUDE [open-code-editor-single-script](../../includes/open-code-editor-single-script.md)]
 
 ```TypeScript
 /**

--- a/docs/resources/samples/table-of-contents.md
+++ b/docs/resources/samples/table-of-contents.md
@@ -1,7 +1,7 @@
 ---
 title: Create a workbook table of contents
 description: Learn how to create a table of contents with links to each worksheet.
-ms.date: 08/08/2023
+ms.date: 12/22/2025
 ms.localizationpriority: medium
 ---
 
@@ -20,7 +20,7 @@ This workbook contains the data, objects, and formatting expected by the script.
 
 ## Sample code: Create a workbook table of contents
 
-Add the following script to the sample workbook and try the sample yourself!
+[!INCLUDE [open-code-editor-single-script](../../includes/open-code-editor-single-script.md)]
 
 ```TypeScript
 function main(workbook: ExcelScript.Workbook) {

--- a/docs/resources/samples/table-samples.md
+++ b/docs/resources/samples/table-samples.md
@@ -1,13 +1,15 @@
 ---
 title: Table samples
 description: A collection of samples showing how to interact with Excel tables.
-ms.date: 01/29/2025
+ms.date: 12/22/2025
 ms.localizationpriority: medium
 ---
 
 # Table samples
 
 These samples showcase common interactions with Excel tables.
+
+[!INCLUDE [open-code-editor](../../includes/open-code-editor.md)]
 
 ## Create a sorted table
 

--- a/docs/resources/samples/write-large-dataset.md
+++ b/docs/resources/samples/write-large-dataset.md
@@ -1,7 +1,7 @@
 ---
 title: Write a large dataset
 description: Learn how to split a large dataset into smaller write operations in Office Scripts.
-ms.date: 02/08/2024
+ms.date: 12/22/2025
 ms.localizationpriority: medium
 ---
 
@@ -12,6 +12,8 @@ The `Range.setValues()` API puts data in a range. This API has limitations depen
 The first part of the sample shows how to write a large dataset in Excel. The second part expands the example to be part of a Power Automate flow. This is necessary if your script takes longer to run than the [Power Automate action timeout](../../testing/platform-limits.md#power-automate).
 
 For performance basics in Office Scripts, please read [Improve the performance of your Office Scripts](../../develop/web-client-performance.md).
+
+[!INCLUDE [open-code-editor](../../includes/open-code-editor.md)]
 
 ## Sample 1: Write a large dataset in batches
 
@@ -155,7 +157,7 @@ For this sample, you'll need to complete the following steps.
 1. Create a second workbook in OneDrive named **TargetWorkbook.xlsx**.
 1. Open **SampleData.xlsx** with Excel.
 1. Add sample data. You can use the script from the [Write a large dataset in batches](#sample-1-write-a-large-dataset-in-batches) section to generate this data.
-1. Create and save both of the following scripts. Use **Automate** > **New Script** to paste the code and save the scripts with the suggested names.
+1. Create and save both of the following scripts. Use **Automate** > **New Script** > **Create in Code Editor** to paste the code and save the scripts with the suggested names.
 1. Follow the steps under [Power Automate flow: Read and write data in a loop](#power-automate-flow-read-and-write-data-in-a-loop) to create the flow.
 
 ### Sample code: Read selected rows

--- a/docs/resources/scenarios/analyze-web-downloads.md
+++ b/docs/resources/scenarios/analyze-web-downloads.md
@@ -1,7 +1,7 @@
 ---
 title: 'Office Scripts sample scenario: Analyze web downloads'
 description: A sample that takes raw internet traffic data in an Excel workbook and determines the origin location, before organizing that information into a table.
-ms.date: 08/08/2023
+ms.date: 12/22/2025
 ms.localizationpriority: medium
 ---
 
@@ -28,7 +28,7 @@ You'll develop a script that analyzes weekly downloads data in the active worksh
 
 1. Open the workbook in Excel.
 
-1. Under the **Automate** tab, select **New Script** and paste the following script into the editor.
+1. Under the **Automate** tab, select **New Script** > **Create in Code Editor**. Paste the following script into the editor.
 
     ```TypeScript
     function main(workbook: ExcelScript.Workbook) {

--- a/docs/resources/scenarios/grade-calculator.md
+++ b/docs/resources/scenarios/grade-calculator.md
@@ -1,7 +1,7 @@
 ---
 title: 'Office Scripts sample scenario: Grade calculator'
 description: A sample that determines the percentage and letter grades for a class of students.
-ms.date: 10/01/2022
+ms.date: 12/22/2025
 ms.localizationpriority: medium
 ---
 
@@ -26,7 +26,7 @@ You'll develop a script that totals the grades for each point category. It will 
 
 1. Open the workbook in Excel.
 
-1. Under the **Automate** tab, select **New Script** and paste the following script into the editor.
+1. Under the **Automate** tab, select **New Script** > **Create in Code Editor**. Paste the following script into the editor.
 
     ```TypeScript
     function main(workbook: ExcelScript.Workbook) {

--- a/docs/resources/scenarios/noaa-data-fetch.md
+++ b/docs/resources/scenarios/noaa-data-fetch.md
@@ -1,7 +1,7 @@
 ---
 title: 'Office Scripts sample scenario: Graph water-level data from NOAA'
 description: A sample that fetches JSON data from a NOAA database and uses it to create a chart.
-ms.date: 03/08/2022
+ms.date: 12/22/2025
 ms.localizationpriority: medium
 ---
 
@@ -23,7 +23,7 @@ For more information about working with JSON, read [Use JSON to pass data to and
 
 1. Open the workbook in Excel.
 
-1. Under the **Automate** tab, select **New Script** and paste the following script into the editor.
+1. Under the **Automate** tab, select **New Script** > **Create in Code Editor**. Paste the following script into the editor.
 
     ```TypeScript
     /**

--- a/docs/resources/scenarios/punch-clock.md
+++ b/docs/resources/scenarios/punch-clock.md
@@ -1,7 +1,7 @@
 ---
 title: 'Office Scripts sample scenario: Punch clock button'
 description: This sample adds a punch clock button and allows a user to clock in and clock out using the current time.
-ms.date: 02/07/2024
+ms.date: 12/22/2025
 ms.localizationpriority: medium
 ---
 
@@ -23,7 +23,7 @@ In this scenario, you'll create a time sheet for an employee that allows them to
 
 1. Open the workbook in Excel.
 
-1. Under the **Automate** tab, select **New Script** and paste the following script into the editor.
+1. Under the **Automate** tab, select **New Script** > **Create in Code Editor**. Paste the following script into the editor.
 
     ```typescript
     /**

--- a/docs/resources/scenarios/schedule-interviews-in-teams.md
+++ b/docs/resources/scenarios/schedule-interviews-in-teams.md
@@ -1,7 +1,7 @@
 ---
 title: Schedule interviews in Teams
 description: Learn how to use Office Scripts to send a Teams meeting from Excel data.
-ms.date: 11/30/2023
+ms.date: 12/22/2025
 ms.localizationpriority: medium
 ---
 
@@ -37,7 +37,7 @@ For more information about working with JSON, read [Use JSON to pass data to and
 
 ### Create the scripts
 
-1. Under the **Automate** tab, select **New Script** and paste the following script into the editor. This will extract table data to schedule invites.
+1. Under the **Automate** tab, select **New Script** > **Create in Code Editor**. Paste the following script into the editor. This will extract table data to schedule invites.
 
 ```TypeScript
 function main(workbook: ExcelScript.Workbook): InterviewInvite[] {

--- a/docs/resources/scenarios/task-reminders.md
+++ b/docs/resources/scenarios/task-reminders.md
@@ -1,7 +1,7 @@
 ---
 title: 'Office Scripts sample scenario: Automated task reminders'
 description: A sample that uses Power Automate and Adaptive Cards automate task reminders in a project management spreadsheet.
-ms.date: 11/30/2023
+ms.date: 12/22/2025
 ms.localizationpriority: medium
 ---
 
@@ -35,7 +35,7 @@ This scenario uses [Power Automate](https://make.powerautomate.com) and [Microso
 
 ### Create the scripts
 
-1. First, we need a script to get all the employees with status reports that are missing from the spreadsheet. Under the **Automate** tab, select **New Script** and paste the following script into the editor.
+1. First, we need a script to get all the employees with status reports that are missing from the spreadsheet. Under the **Automate** tab, select **New Script** > **Create in Code Editor**. Paste the following script into the editor.
 
     ```TypeScript
     /**
@@ -88,7 +88,7 @@ This scenario uses [Power Automate](https://make.powerautomate.com) and [Microso
 
 1. Save the script with the name **Get People**.
 
-1. Next, we need a second script to process the status report cards and put the new information in the spreadsheet. In the Code Editor task pane, select **New Script** and paste the following script into the editor.
+1. Next, we need a second script to process the status report cards and put the new information in the spreadsheet. In the Code Editor task pane, select **New Script** > **Create in Code Editor**. Paste the following script into the editor.
 
     ```TypeScript
     /**

--- a/docs/tutorials/excel-power-automate-manual.md
+++ b/docs/tutorials/excel-power-automate-manual.md
@@ -1,7 +1,7 @@
 ---
 title: 'Tutorial: Update a spreadsheet from a Power Automate flow'
 description: A tutorial about how to use an Office Script in Power Automate through a manual trigger.
-ms.date: 11/29/2023
+ms.date: 12/22/2025
 ms.localizationpriority: high
 ---
 
@@ -26,7 +26,7 @@ Power Automate shouldn't use [relative references](../testing/power-automate-tro
 
 ## Create an Office Script
 
-1. Go to the **Automate** tab and select **New Script**.
+1. Go to the **Automate** tab and select **New Script** > **Create in Code Editor**.
 
 1. Replace the default script with the following script. This script adds the current date and time to the first two cells of the **TutorialWorksheet** worksheet.
 

--- a/docs/tutorials/excel-power-automate-returns.md
+++ b/docs/tutorials/excel-power-automate-returns.md
@@ -1,7 +1,7 @@
 ---
 title: 'Tutorial: Send weekly email reminders based on spreadsheet data'
 description: A tutorial that shows how to send reminder emails by running Office Scripts for Excel through Power Automate.
-ms.date: 11/29/2023
+ms.date: 12/22/2025
 ms.localizationpriority: high
 ---
 
@@ -35,7 +35,7 @@ This tutorial teaches you how to return information from an Office Script for Ex
 
 ## Create an Office Script
 
-1. Go to the **Automate** tab and select **New Script**.
+1. Go to the **Automate** tab and select **New Script** > **Create in Code Editor**.
 
 1. Name the script **Get On-Call Person**.
 

--- a/docs/tutorials/excel-power-automate-trigger.md
+++ b/docs/tutorials/excel-power-automate-trigger.md
@@ -1,7 +1,7 @@
 ---
 title: 'Tutorial: Automatically save content from emails in a workbook'
 description: A tutorial about running Office Scripts for Excel through Power Automate when mail is received and passing flow data to the script.
-ms.date: 11/14/2025
+ms.date: 12/22/2025
 ms.localizationpriority: high
 ---
 
@@ -22,7 +22,7 @@ Power Automate shouldn't use [relative references](../testing/power-automate-tro
 
 1. Create a new workbook named **MyWorkbook**.
 
-1. Go to the **Automate** tab and select **New Script**.
+1. Go to the **Automate** tab and select **New Script** > **Create in Code Editor**.
 
 1. Replace the existing code with the following script and select **Run**. This step sets up the workbook with consistent worksheet, table, and PivotTable names.
 
@@ -53,7 +53,7 @@ Power Automate shouldn't use [relative references](../testing/power-automate-tro
 
 Create a script that logs information from an email. You want to track which days of the week you receive the most mail and how many unique senders send that mail. Your workbook has a table with **Date**, **Day of the week**, **Email address**, and **Subject** columns. Your worksheet also has a PivotTable that pivots on the **Day of the week** and **Email address** (those are the row hierarchies). The count of unique **Subjects** is the aggregated information being displayed (the data hierarchy). The script refreshes that PivotTable after it updates the email table.
 
-1. From within the Code Editor task pane, select **New Script**.
+1. From within the Code Editor task pane, select **New Script** > **Create in Code Editor**.
 
 1. The flow that you create later in the tutorial sends the script information about each email that's received. The script needs to accept that input through parameters in the `main` function. Replace the default script with the following script.
 

--- a/docs/tutorials/excel-read-tutorial.md
+++ b/docs/tutorials/excel-read-tutorial.md
@@ -1,7 +1,7 @@
 ---
 title: 'Tutorial: Clean and normalize Excel workbook data'
 description: An Office Scripts tutorial about reading data from workbooks and evaluating that data in the script.
-ms.date: 11/29/2023
+ms.date: 12/22/2025
 ms.localizationpriority: high
 ---
 
@@ -37,7 +37,7 @@ Over the rest of the tutorial, you'll normalize this data using a script. First,
     |10/25/2019 |Checking |Best For You Organics Company | -85.64 | |
     |11/01/2019 |Checking |External Deposit | |1000 |
 
-1. Go to the **Automate** tab and select **New Script**.
+1. Go to the **Automate** tab and select **New Script** > **Create in Code Editor**.
 1. Clean up the formatting. This is a financial document, so have your script change the number formatting in the **Debit** and **Credit** columns to show values as dollar amounts. Also have your script fit the column width to the data.
 
     Replace the script contents with the following code:

--- a/docs/tutorials/excel-tutorial.md
+++ b/docs/tutorials/excel-tutorial.md
@@ -1,7 +1,7 @@
 ---
 title: "Tutorial: Create and format an Excel table"
 description: A tutorial about the basics of Office Scripts, including recording scripts with the Action Recorder and writing data to a workbook.
-ms.date: 09/20/2024
+ms.date: 12/22/2025
 ms.localizationpriority: high
 ---
 
@@ -31,7 +31,7 @@ First, you'll need some data and a small starting script.
     |Grapefruits |900 |700 |
 
 1. Open the **Automate** tab. If you don't see the **Automate** tab, check the ribbon overflow by selecting the drop-down arrow. If it's still not there, follow the advice in the article [Troubleshoot Office Scripts](../testing/troubleshooting.md#automate-tab-not-appearing-or-office-scripts-unavailable).
-1. Select the **Record Actions** button.
+1. Select **New Script** > **Create from Recording** button.
 1. Select cells **A2:C2** (the "Oranges" row) and set the fill color to orange.
 1. Stop the recording by selecting the **Stop** button.
 


### PR DESCRIPTION
We received feedback on the docs that it wasn't apparent where you were supposed to paste the Office Scripts code samples. This PR aims to make that more apparent.